### PR TITLE
Add new apps and fixed a typo in MessagesTest.swift

### DIFF
--- a/Appz/Appz.xcodeproj/project.pbxproj
+++ b/Appz/Appz.xcodeproj/project.pbxproj
@@ -33,6 +33,30 @@
 		5467389A1C3996A200AA42F1 /* ScannerProTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546738891C3996A200AA42F1 /* ScannerProTests.swift */; };
 		5467389B1C3996A200AA42F1 /* SkypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467388A1C3996A200AA42F1 /* SkypeTests.swift */; };
 		5467389C1C3996A200AA42F1 /* SkypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467388A1C3996A200AA42F1 /* SkypeTests.swift */; };
+		5474DDD11C3B141100300281 /* Excel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCC1C3B141100300281 /* Excel.swift */; };
+		5474DDD21C3B141100300281 /* MSPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCD1C3B141100300281 /* MSPayload.swift */; };
+		5474DDD31C3B141100300281 /* OneNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCE1C3B141100300281 /* OneNote.swift */; };
+		5474DDD41C3B141100300281 /* PowerPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCF1C3B141100300281 /* PowerPoint.swift */; };
+		5474DDD51C3B141100300281 /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDD01C3B141100300281 /* Word.swift */; };
+		5474DDD61C3B14CD00300281 /* MailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316121C38539F00CEFE92 /* MailTests.swift */; };
+		5474DDD81C3B14E600300281 /* ExcelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDD71C3B14E600300281 /* ExcelTests.swift */; };
+		5474DDD91C3B14ED00300281 /* Excel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCC1C3B141100300281 /* Excel.swift */; };
+		5474DDDA1C3B14ED00300281 /* Excel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCC1C3B141100300281 /* Excel.swift */; };
+		5474DDDB1C3B14F000300281 /* MSPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCD1C3B141100300281 /* MSPayload.swift */; };
+		5474DDDC1C3B14F100300281 /* MSPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCD1C3B141100300281 /* MSPayload.swift */; };
+		5474DDDD1C3B14F400300281 /* OneNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCE1C3B141100300281 /* OneNote.swift */; };
+		5474DDDE1C3B14F400300281 /* OneNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCE1C3B141100300281 /* OneNote.swift */; };
+		5474DDDF1C3B14F700300281 /* PowerPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCF1C3B141100300281 /* PowerPoint.swift */; };
+		5474DDE01C3B14F800300281 /* PowerPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDCF1C3B141100300281 /* PowerPoint.swift */; };
+		5474DDE11C3B14FC00300281 /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDD01C3B141100300281 /* Word.swift */; };
+		5474DDE21C3B14FD00300281 /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDD01C3B141100300281 /* Word.swift */; };
+		5474DDE41C3B15F800300281 /* OneNoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDE31C3B15F800300281 /* OneNoteTests.swift */; };
+		5474DDE51C3B164600300281 /* ExcelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDD71C3B14E600300281 /* ExcelTests.swift */; };
+		5474DDE61C3B164B00300281 /* OneNoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDE31C3B15F800300281 /* OneNoteTests.swift */; };
+		5474DDE81C3B165D00300281 /* PowerPointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDE71C3B165D00300281 /* PowerPointTests.swift */; };
+		5474DDE91C3B16A700300281 /* PowerPointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDE71C3B165D00300281 /* PowerPointTests.swift */; };
+		5474DDEB1C3B16BA00300281 /* WordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDEA1C3B16BA00300281 /* WordTests.swift */; };
+		5474DDEC1C3B170B00300281 /* WordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5474DDEA1C3B16BA00300281 /* WordTests.swift */; };
 		5480421A1C3A5AE300BBE49E /* OneDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042161C3A5AE300BBE49E /* OneDrive.swift */; };
 		5480421B1C3A5AE300BBE49E /* Outlook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042171C3A5AE300BBE49E /* Outlook.swift */; };
 		5480421C1C3A5AE300BBE49E /* Sonos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042181C3A5AE300BBE49E /* Sonos.swift */; };
@@ -232,7 +256,6 @@
 		82F316411C38539F00CEFE92 /* ItranslateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316111C38539F00CEFE92 /* ItranslateTests.swift */; };
 		82F316421C38539F00CEFE92 /* ItranslateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316111C38539F00CEFE92 /* ItranslateTests.swift */; };
 		82F316431C38539F00CEFE92 /* MailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316121C38539F00CEFE92 /* MailTests.swift */; };
-		82F316441C38539F00CEFE92 /* MailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316121C38539F00CEFE92 /* MailTests.swift */; };
 		82F316451C38539F00CEFE92 /* MessagesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316131C38539F00CEFE92 /* MessagesTest.swift */; };
 		82F316461C38539F00CEFE92 /* MessagesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316131C38539F00CEFE92 /* MessagesTest.swift */; };
 		82F316471C38539F00CEFE92 /* PaypalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F316141C38539F00CEFE92 /* PaypalTests.swift */; };
@@ -290,6 +313,15 @@
 		546738881C3996A200AA42F1 /* RemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteTests.swift; sourceTree = "<group>"; };
 		546738891C3996A200AA42F1 /* ScannerProTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerProTests.swift; sourceTree = "<group>"; };
 		5467388A1C3996A200AA42F1 /* SkypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkypeTests.swift; sourceTree = "<group>"; };
+		5474DDCC1C3B141100300281 /* Excel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Excel.swift; sourceTree = "<group>"; };
+		5474DDCD1C3B141100300281 /* MSPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSPayload.swift; sourceTree = "<group>"; };
+		5474DDCE1C3B141100300281 /* OneNote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneNote.swift; sourceTree = "<group>"; };
+		5474DDCF1C3B141100300281 /* PowerPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PowerPoint.swift; sourceTree = "<group>"; };
+		5474DDD01C3B141100300281 /* Word.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
+		5474DDD71C3B14E600300281 /* ExcelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExcelTests.swift; sourceTree = "<group>"; };
+		5474DDE31C3B15F800300281 /* OneNoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneNoteTests.swift; sourceTree = "<group>"; };
+		5474DDE71C3B165D00300281 /* PowerPointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PowerPointTests.swift; sourceTree = "<group>"; };
+		5474DDEA1C3B16BA00300281 /* WordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordTests.swift; sourceTree = "<group>"; };
 		548042161C3A5AE300BBE49E /* OneDrive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneDrive.swift; sourceTree = "<group>"; };
 		548042171C3A5AE300BBE49E /* Outlook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Outlook.swift; sourceTree = "<group>"; };
 		548042181C3A5AE300BBE49E /* Sonos.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sonos.swift; sourceTree = "<group>"; };
@@ -474,6 +506,10 @@
 				82F3161C1C38539F00CEFE92 /* WhatsAppTests.swift */,
 				82F3161D1C38539F00CEFE92 /* YelpTests.swift */,
 				82F3161E1C38539F00CEFE92 /* YoutubeTests.swift */,
+				5474DDD71C3B14E600300281 /* ExcelTests.swift */,
+				5474DDE31C3B15F800300281 /* OneNoteTests.swift */,
+				5474DDE71C3B165D00300281 /* PowerPointTests.swift */,
+				5474DDEA1C3B16BA00300281 /* WordTests.swift */,
 			);
 			path = AppsTests;
 			sourceTree = "<group>";
@@ -553,6 +589,11 @@
 		826ACF1C1BF1BE9C00B5FC5D /* Apps */ = {
 			isa = PBXGroup;
 			children = (
+				5474DDCC1C3B141100300281 /* Excel.swift */,
+				5474DDCD1C3B141100300281 /* MSPayload.swift */,
+				5474DDCE1C3B141100300281 /* OneNote.swift */,
+				5474DDCF1C3B141100300281 /* PowerPoint.swift */,
+				5474DDD01C3B141100300281 /* Word.swift */,
 				548042161C3A5AE300BBE49E /* OneDrive.swift */,
 				548042171C3A5AE300BBE49E /* Outlook.swift */,
 				548042181C3A5AE300BBE49E /* Sonos.swift */,
@@ -833,15 +874,18 @@
 				82F315CE1C38538100CEFE92 /* IMDb.swift in Sources */,
 				54D5D0031C3995EE0039D512 /* Linkedin.swift in Sources */,
 				54D5D0061C3995EE0039D512 /* Music.swift in Sources */,
+				5474DDDD1C3B14F400300281 /* OneNote.swift in Sources */,
 				82F315B61C38538100CEFE92 /* Facebook.swift in Sources */,
 				54D5D00F1C3995EE0039D512 /* Remote.swift in Sources */,
 				5480421E1C3A5AE700BBE49E /* OneDrive.swift in Sources */,
 				82F315CB1C38538100CEFE92 /* Ibooks.swift in Sources */,
 				82F315C81C38538100CEFE92 /* GooglePlus.swift in Sources */,
+				5474DDE11C3B14FC00300281 /* Word.swift in Sources */,
 				82F315C21C38538100CEFE92 /* GoogleMail.swift in Sources */,
 				82F315E01C38538100CEFE92 /* Paypal.swift in Sources */,
 				82F315D11C38538100CEFE92 /* INRIXTraffic.swift in Sources */,
 				82F315B91C38538100CEFE92 /* FindFriends.swift in Sources */,
+				5474DDDB1C3B14F000300281 /* MSPayload.swift in Sources */,
 				82F315BC1C38538100CEFE92 /* Flickr.swift in Sources */,
 				5480421F1C3A5AEA00BBE49E /* Outlook.swift in Sources */,
 				82F315FB1C38538100CEFE92 /* Yelp.swift in Sources */,
@@ -866,8 +910,10 @@
 				54D5D0121C3995EE0039D512 /* ScannerPro.swift in Sources */,
 				82F315EC1C38538100CEFE92 /* Telegram.swift in Sources */,
 				54D5D00C1C3995EE0039D512 /* RemindersApp.swift in Sources */,
+				5474DDDF1C3B14F700300281 /* PowerPoint.swift in Sources */,
 				82F315D41C38538100CEFE92 /* Instagram.swift in Sources */,
 				82F315C51C38538100CEFE92 /* GoogleMaps.swift in Sources */,
+				5474DDD91C3B14ED00300281 /* Excel.swift in Sources */,
 				8254C78E1C2608BA009DB3BD /* UIApplication+ApplicationCaller.swift in Sources */,
 				54D5D0001C3995EE0039D512 /* GoogleDrive.swift in Sources */,
 				82F315F21C38538100CEFE92 /* Twitter.swift in Sources */,
@@ -881,13 +927,14 @@
 			files = (
 				54244A221C3A5BB100AA064F /* OutlookTests.swift in Sources */,
 				82F316301C38539F00CEFE92 /* FlickrTests.swift in Sources */,
+				5474DDD61C3B14CD00300281 /* MailTests.swift in Sources */,
 				82F3164C1C38539F00CEFE92 /* QuoraTests.swift in Sources */,
 				82F316361C38539F00CEFE92 /* GoogleMapsTests.swift in Sources */,
-				82F316441C38539F00CEFE92 /* MailTests.swift in Sources */,
 				82F316481C38539F00CEFE92 /* PaypalTests.swift in Sources */,
 				82F3163A1C38539F00CEFE92 /* IbooksTests.swift in Sources */,
 				82F316561C38539F00CEFE92 /* ViberTests.swift in Sources */,
 				82F316261C38539F00CEFE92 /* DocumentsTests.swift in Sources */,
+				5474DDEC1C3B170B00300281 /* WordTests.swift in Sources */,
 				82F316241C38539F00CEFE92 /* DayOneTests.swift in Sources */,
 				82F3162A1C38539F00CEFE92 /* EbayTests.swift in Sources */,
 				82F3164A1C38539F00CEFE92 /* PinterestTests.swift in Sources */,
@@ -906,6 +953,7 @@
 				8254C7AF1C260A3B009DB3BD /* ApplicationCallerMock.swift in Sources */,
 				82F316401C38539F00CEFE92 /* InstagramTests.swift in Sources */,
 				82F3163C1C38539F00CEFE92 /* IMDbTests.swift in Sources */,
+				5474DDE51C3B164600300281 /* ExcelTests.swift in Sources */,
 				5467388E1C3996A200AA42F1 /* GoogleDriveTests.swift in Sources */,
 				546738981C3996A200AA42F1 /* RemoteTests.swift in Sources */,
 				82F3162C1C38539F00CEFE92 /* FacebookTests.swift in Sources */,
@@ -914,12 +962,14 @@
 				54244A201C3A5BAB00AA064F /* VideosTests.swift in Sources */,
 				54244A211C3A5BAE00AA064F /* SonosTests.swift in Sources */,
 				82F316541C38539F00CEFE92 /* TwitterTests.swift in Sources */,
+				5474DDE61C3B164B00300281 /* OneNoteTests.swift in Sources */,
 				82F316421C38539F00CEFE92 /* ItranslateTests.swift in Sources */,
 				82F3165C1C38539F00CEFE92 /* YoutubeTests.swift in Sources */,
 				82F316581C38539F00CEFE92 /* WhatsAppTests.swift in Sources */,
 				8254C7B01C260A3B009DB3BD /* SampleApp.swift in Sources */,
 				82F316501C38539F00CEFE92 /* TelegramTests.swift in Sources */,
 				546738921C3996A200AA42F1 /* MusicTests.swift in Sources */,
+				5474DDE91C3B16A700300281 /* PowerPointTests.swift in Sources */,
 				82F3165A1C38539F00CEFE92 /* YelpTests.swift in Sources */,
 				82F316341C38539F00CEFE92 /* GoogleMailTests.swift in Sources */,
 				54244A231C3A5BB300AA064F /* OneDriveTests.swift in Sources */,
@@ -965,6 +1015,7 @@
 				82F315F01C38538100CEFE92 /* Tweetbot.swift in Sources */,
 				82F315ED1C38538100CEFE92 /* Telegram.swift in Sources */,
 				82F315A51C38538100CEFE92 /* AppStore.swift in Sources */,
+				5474DDDE1C3B14F400300281 /* OneNote.swift in Sources */,
 				82F315A81C38538100CEFE92 /* Audible.swift in Sources */,
 				8254C7BD1C260DA8009DB3BD /* Applications.swift in Sources */,
 				54D5D0011C3995EE0039D512 /* GoogleDrive.swift in Sources */,
@@ -976,13 +1027,17 @@
 				82F315C01C38538100CEFE92 /* GoogleEarth.swift in Sources */,
 				54D5D0161C3995EE0039D512 /* Skype.swift in Sources */,
 				54D5D00D1C3995EE0039D512 /* RemindersApp.swift in Sources */,
+				5474DDDC1C3B14F100300281 /* MSPayload.swift in Sources */,
 				82F315C31C38538100CEFE92 /* GoogleMail.swift in Sources */,
 				82F315B41C38538100CEFE92 /* Ebay.swift in Sources */,
 				82F315F31C38538100CEFE92 /* Twitter.swift in Sources */,
+				5474DDE21C3B14FD00300281 /* Word.swift in Sources */,
 				82F315F61C38538100CEFE92 /* Viber.swift in Sources */,
 				82F315AE1C38538100CEFE92 /* Documents.swift in Sources */,
 				82F315BD1C38538100CEFE92 /* Flickr.swift in Sources */,
 				82F315AB1C38538100CEFE92 /* DayOne.swift in Sources */,
+				5474DDDA1C3B14ED00300281 /* Excel.swift in Sources */,
+				5474DDE01C3B14F800300281 /* PowerPoint.swift in Sources */,
 				82F315C61C38538100CEFE92 /* GoogleMaps.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1002,15 +1057,18 @@
 				82F315CD1C38538100CEFE92 /* IMDb.swift in Sources */,
 				54D5D0021C3995EE0039D512 /* Linkedin.swift in Sources */,
 				54D5D0051C3995EE0039D512 /* Music.swift in Sources */,
+				5474DDD31C3B141100300281 /* OneNote.swift in Sources */,
 				82F315B51C38538100CEFE92 /* Facebook.swift in Sources */,
 				54D5D00E1C3995EE0039D512 /* Remote.swift in Sources */,
 				5480421A1C3A5AE300BBE49E /* OneDrive.swift in Sources */,
 				82F315CA1C38538100CEFE92 /* Ibooks.swift in Sources */,
 				82F315C71C38538100CEFE92 /* GooglePlus.swift in Sources */,
+				5474DDD51C3B141100300281 /* Word.swift in Sources */,
 				82F315C11C38538100CEFE92 /* GoogleMail.swift in Sources */,
 				82F315DF1C38538100CEFE92 /* Paypal.swift in Sources */,
 				82F315D01C38538100CEFE92 /* INRIXTraffic.swift in Sources */,
 				82F315B81C38538100CEFE92 /* FindFriends.swift in Sources */,
+				5474DDD21C3B141100300281 /* MSPayload.swift in Sources */,
 				82F315BB1C38538100CEFE92 /* Flickr.swift in Sources */,
 				5480421B1C3A5AE300BBE49E /* Outlook.swift in Sources */,
 				82F315FA1C38538100CEFE92 /* Yelp.swift in Sources */,
@@ -1035,8 +1093,10 @@
 				54D5D0111C3995EE0039D512 /* ScannerPro.swift in Sources */,
 				82F315EB1C38538100CEFE92 /* Telegram.swift in Sources */,
 				54D5D00B1C3995EE0039D512 /* RemindersApp.swift in Sources */,
+				5474DDD41C3B141100300281 /* PowerPoint.swift in Sources */,
 				82F315D31C38538100CEFE92 /* Instagram.swift in Sources */,
 				82F315C41C38538100CEFE92 /* GoogleMaps.swift in Sources */,
+				5474DDD11C3B141100300281 /* Excel.swift in Sources */,
 				826ACF251BF1C00800B5FC5D /* UIApplication+ApplicationCaller.swift in Sources */,
 				54D5CFFF1C3995EE0039D512 /* GoogleDrive.swift in Sources */,
 				82F315F11C38538100CEFE92 /* Twitter.swift in Sources */,
@@ -1057,6 +1117,7 @@
 				82F316551C38539F00CEFE92 /* ViberTests.swift in Sources */,
 				82F316251C38539F00CEFE92 /* DocumentsTests.swift in Sources */,
 				82F316231C38539F00CEFE92 /* DayOneTests.swift in Sources */,
+				5474DDEB1C3B16BA00300281 /* WordTests.swift in Sources */,
 				54244A1C1C3A5B7F00AA064F /* OneDriveTests.swift in Sources */,
 				82F316291C38539F00CEFE92 /* EbayTests.swift in Sources */,
 				82F316491C38539F00CEFE92 /* PinterestTests.swift in Sources */,
@@ -1075,6 +1136,7 @@
 				82F3164D1C38539F00CEFE92 /* SettingsTests.swift in Sources */,
 				8254C77E1C25751A009DB3BD /* SampleApp.swift in Sources */,
 				82F3163F1C38539F00CEFE92 /* InstagramTests.swift in Sources */,
+				5474DDD81C3B14E600300281 /* ExcelTests.swift in Sources */,
 				82F3163B1C38539F00CEFE92 /* IMDbTests.swift in Sources */,
 				5467388D1C3996A200AA42F1 /* GoogleDriveTests.swift in Sources */,
 				546738971C3996A200AA42F1 /* RemoteTests.swift in Sources */,
@@ -1083,12 +1145,14 @@
 				82F3163D1C38539F00CEFE92 /* INRIXTrafficTests.swift in Sources */,
 				546738991C3996A200AA42F1 /* ScannerProTests.swift in Sources */,
 				82F316531C38539F00CEFE92 /* TwitterTests.swift in Sources */,
+				5474DDE41C3B15F800300281 /* OneNoteTests.swift in Sources */,
 				82F316411C38539F00CEFE92 /* ItranslateTests.swift in Sources */,
 				82F3165B1C38539F00CEFE92 /* YoutubeTests.swift in Sources */,
 				82F316571C38539F00CEFE92 /* WhatsAppTests.swift in Sources */,
 				827EF6171BF2756C000B1607 /* ApplicationCallerMock.swift in Sources */,
 				82F3164F1C38539F00CEFE92 /* TelegramTests.swift in Sources */,
 				546738911C3996A200AA42F1 /* MusicTests.swift in Sources */,
+				5474DDE81C3B165D00300281 /* PowerPointTests.swift in Sources */,
 				82F316591C38539F00CEFE92 /* YelpTests.swift in Sources */,
 				82F316331C38539F00CEFE92 /* GoogleMailTests.swift in Sources */,
 				82F316211C38539F00CEFE92 /* AudibleTests.swift in Sources */,

--- a/Appz/Appz.xcodeproj/project.pbxproj
+++ b/Appz/Appz.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		54244A1C1C3A5B7F00AA064F /* OneDriveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A141C3A5B7A00AA064F /* OneDriveTests.swift */; };
+		54244A1D1C3A5B8300AA064F /* OutlookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A151C3A5B7A00AA064F /* OutlookTests.swift */; };
+		54244A1E1C3A5B8700AA064F /* SonosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A161C3A5B7A00AA064F /* SonosTests.swift */; };
+		54244A1F1C3A5B8B00AA064F /* VideosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A171C3A5B7A00AA064F /* VideosTests.swift */; };
+		54244A201C3A5BAB00AA064F /* VideosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A171C3A5B7A00AA064F /* VideosTests.swift */; };
+		54244A211C3A5BAE00AA064F /* SonosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A161C3A5B7A00AA064F /* SonosTests.swift */; };
+		54244A221C3A5BB100AA064F /* OutlookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A151C3A5B7A00AA064F /* OutlookTests.swift */; };
+		54244A231C3A5BB300AA064F /* OneDriveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54244A141C3A5B7A00AA064F /* OneDriveTests.swift */; };
 		5467388B1C3996A200AA42F1 /* GoogleChromeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546738821C3996A200AA42F1 /* GoogleChromeTests.swift */; };
 		5467388C1C3996A200AA42F1 /* GoogleChromeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546738821C3996A200AA42F1 /* GoogleChromeTests.swift */; };
 		5467388D1C3996A200AA42F1 /* GoogleDriveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546738831C3996A200AA42F1 /* GoogleDriveTests.swift */; };
@@ -25,6 +33,18 @@
 		5467389A1C3996A200AA42F1 /* ScannerProTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546738891C3996A200AA42F1 /* ScannerProTests.swift */; };
 		5467389B1C3996A200AA42F1 /* SkypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467388A1C3996A200AA42F1 /* SkypeTests.swift */; };
 		5467389C1C3996A200AA42F1 /* SkypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5467388A1C3996A200AA42F1 /* SkypeTests.swift */; };
+		5480421A1C3A5AE300BBE49E /* OneDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042161C3A5AE300BBE49E /* OneDrive.swift */; };
+		5480421B1C3A5AE300BBE49E /* Outlook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042171C3A5AE300BBE49E /* Outlook.swift */; };
+		5480421C1C3A5AE300BBE49E /* Sonos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042181C3A5AE300BBE49E /* Sonos.swift */; };
+		5480421D1C3A5AE300BBE49E /* Videos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042191C3A5AE300BBE49E /* Videos.swift */; };
+		5480421E1C3A5AE700BBE49E /* OneDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042161C3A5AE300BBE49E /* OneDrive.swift */; };
+		5480421F1C3A5AEA00BBE49E /* Outlook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042171C3A5AE300BBE49E /* Outlook.swift */; };
+		548042201C3A5AED00BBE49E /* Sonos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042181C3A5AE300BBE49E /* Sonos.swift */; };
+		548042211C3A5AF500BBE49E /* OneDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042161C3A5AE300BBE49E /* OneDrive.swift */; };
+		548042221C3A5AF700BBE49E /* Outlook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042171C3A5AE300BBE49E /* Outlook.swift */; };
+		548042231C3A5AFA00BBE49E /* Videos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042191C3A5AE300BBE49E /* Videos.swift */; };
+		548042241C3A5AFB00BBE49E /* Videos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042191C3A5AE300BBE49E /* Videos.swift */; };
+		548042251C3A5AFE00BBE49E /* Sonos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548042181C3A5AE300BBE49E /* Sonos.swift */; };
 		54D5CFFC1C3995EE0039D512 /* GoogleChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D5CFF31C3995EE0039D512 /* GoogleChrome.swift */; };
 		54D5CFFD1C3995EE0039D512 /* GoogleChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D5CFF31C3995EE0039D512 /* GoogleChrome.swift */; };
 		54D5CFFE1C3995EE0039D512 /* GoogleChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D5CFF31C3995EE0039D512 /* GoogleChrome.swift */; };
@@ -257,6 +277,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		54244A141C3A5B7A00AA064F /* OneDriveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneDriveTests.swift; sourceTree = "<group>"; };
+		54244A151C3A5B7A00AA064F /* OutlookTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutlookTests.swift; sourceTree = "<group>"; };
+		54244A161C3A5B7A00AA064F /* SonosTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SonosTests.swift; sourceTree = "<group>"; };
+		54244A171C3A5B7A00AA064F /* VideosTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideosTests.swift; sourceTree = "<group>"; };
 		546738821C3996A200AA42F1 /* GoogleChromeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleChromeTests.swift; sourceTree = "<group>"; };
 		546738831C3996A200AA42F1 /* GoogleDriveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleDriveTests.swift; sourceTree = "<group>"; };
 		546738841C3996A200AA42F1 /* LinkedinTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkedinTests.swift; sourceTree = "<group>"; };
@@ -266,6 +290,10 @@
 		546738881C3996A200AA42F1 /* RemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteTests.swift; sourceTree = "<group>"; };
 		546738891C3996A200AA42F1 /* ScannerProTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerProTests.swift; sourceTree = "<group>"; };
 		5467388A1C3996A200AA42F1 /* SkypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkypeTests.swift; sourceTree = "<group>"; };
+		548042161C3A5AE300BBE49E /* OneDrive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneDrive.swift; sourceTree = "<group>"; };
+		548042171C3A5AE300BBE49E /* Outlook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Outlook.swift; sourceTree = "<group>"; };
+		548042181C3A5AE300BBE49E /* Sonos.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sonos.swift; sourceTree = "<group>"; };
+		548042191C3A5AE300BBE49E /* Videos.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Videos.swift; sourceTree = "<group>"; };
 		54D5CFF31C3995EE0039D512 /* GoogleChrome.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleChrome.swift; sourceTree = "<group>"; };
 		54D5CFF41C3995EE0039D512 /* GoogleDrive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleDrive.swift; sourceTree = "<group>"; };
 		54D5CFF51C3995EE0039D512 /* Linkedin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Linkedin.swift; sourceTree = "<group>"; };
@@ -402,6 +430,10 @@
 		8246C8C81C1F990D00569119 /* AppsTests */ = {
 			isa = PBXGroup;
 			children = (
+				54244A141C3A5B7A00AA064F /* OneDriveTests.swift */,
+				54244A151C3A5B7A00AA064F /* OutlookTests.swift */,
+				54244A161C3A5B7A00AA064F /* SonosTests.swift */,
+				54244A171C3A5B7A00AA064F /* VideosTests.swift */,
 				546738821C3996A200AA42F1 /* GoogleChromeTests.swift */,
 				546738831C3996A200AA42F1 /* GoogleDriveTests.swift */,
 				546738841C3996A200AA42F1 /* LinkedinTests.swift */,
@@ -521,6 +553,10 @@
 		826ACF1C1BF1BE9C00B5FC5D /* Apps */ = {
 			isa = PBXGroup;
 			children = (
+				548042161C3A5AE300BBE49E /* OneDrive.swift */,
+				548042171C3A5AE300BBE49E /* Outlook.swift */,
+				548042181C3A5AE300BBE49E /* Sonos.swift */,
+				548042191C3A5AE300BBE49E /* Videos.swift */,
 				54D5CFF31C3995EE0039D512 /* GoogleChrome.swift */,
 				54D5CFF41C3995EE0039D512 /* GoogleDrive.swift */,
 				54D5CFF51C3995EE0039D512 /* Linkedin.swift */,
@@ -799,6 +835,7 @@
 				54D5D0061C3995EE0039D512 /* Music.swift in Sources */,
 				82F315B61C38538100CEFE92 /* Facebook.swift in Sources */,
 				54D5D00F1C3995EE0039D512 /* Remote.swift in Sources */,
+				5480421E1C3A5AE700BBE49E /* OneDrive.swift in Sources */,
 				82F315CB1C38538100CEFE92 /* Ibooks.swift in Sources */,
 				82F315C81C38538100CEFE92 /* GooglePlus.swift in Sources */,
 				82F315C21C38538100CEFE92 /* GoogleMail.swift in Sources */,
@@ -806,6 +843,7 @@
 				82F315D11C38538100CEFE92 /* INRIXTraffic.swift in Sources */,
 				82F315B91C38538100CEFE92 /* FindFriends.swift in Sources */,
 				82F315BC1C38538100CEFE92 /* Flickr.swift in Sources */,
+				5480421F1C3A5AEA00BBE49E /* Outlook.swift in Sources */,
 				82F315FB1C38538100CEFE92 /* Yelp.swift in Sources */,
 				8254C7C91C26124D009DB3BD /* NSExtensionContext+ApplicationCaller.swift in Sources */,
 				8254C78C1C2608BA009DB3BD /* Applications.swift in Sources */,
@@ -817,12 +855,14 @@
 				82F315D71C38538100CEFE92 /* Itranslate.swift in Sources */,
 				82F315E61C38538100CEFE92 /* Quora.swift in Sources */,
 				82F315F81C38538100CEFE92 /* WhatsApp.swift in Sources */,
+				548042231C3A5AFA00BBE49E /* Videos.swift in Sources */,
 				82F315DD1C38538100CEFE92 /* Messages.swift in Sources */,
 				82F315EF1C38538100CEFE92 /* Tweetbot.swift in Sources */,
 				82F315BF1C38538100CEFE92 /* GoogleEarth.swift in Sources */,
 				82F315E91C38538100CEFE92 /* Settings.swift in Sources */,
 				54D5CFFD1C3995EE0039D512 /* GoogleChrome.swift in Sources */,
 				82F315DA1C38538100CEFE92 /* Mail.swift in Sources */,
+				548042201C3A5AED00BBE49E /* Sonos.swift in Sources */,
 				54D5D0121C3995EE0039D512 /* ScannerPro.swift in Sources */,
 				82F315EC1C38538100CEFE92 /* Telegram.swift in Sources */,
 				54D5D00C1C3995EE0039D512 /* RemindersApp.swift in Sources */,
@@ -839,6 +879,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				54244A221C3A5BB100AA064F /* OutlookTests.swift in Sources */,
 				82F316301C38539F00CEFE92 /* FlickrTests.swift in Sources */,
 				82F3164C1C38539F00CEFE92 /* QuoraTests.swift in Sources */,
 				82F316361C38539F00CEFE92 /* GoogleMapsTests.swift in Sources */,
@@ -870,6 +911,8 @@
 				82F3162C1C38539F00CEFE92 /* FacebookTests.swift in Sources */,
 				82F3163E1C38539F00CEFE92 /* INRIXTrafficTests.swift in Sources */,
 				5467389A1C3996A200AA42F1 /* ScannerProTests.swift in Sources */,
+				54244A201C3A5BAB00AA064F /* VideosTests.swift in Sources */,
+				54244A211C3A5BAE00AA064F /* SonosTests.swift in Sources */,
 				82F316541C38539F00CEFE92 /* TwitterTests.swift in Sources */,
 				82F316421C38539F00CEFE92 /* ItranslateTests.swift in Sources */,
 				82F3165C1C38539F00CEFE92 /* YoutubeTests.swift in Sources */,
@@ -879,6 +922,7 @@
 				546738921C3996A200AA42F1 /* MusicTests.swift in Sources */,
 				82F3165A1C38539F00CEFE92 /* YelpTests.swift in Sources */,
 				82F316341C38539F00CEFE92 /* GoogleMailTests.swift in Sources */,
+				54244A231C3A5BB300AA064F /* OneDriveTests.swift in Sources */,
 				82F316221C38539F00CEFE92 /* AudibleTests.swift in Sources */,
 				82F3162E1C38539F00CEFE92 /* FindFriendsTests.swift in Sources */,
 				5467389C1C3996A200AA42F1 /* SkypeTests.swift in Sources */,
@@ -895,13 +939,16 @@
 				54D5D00A1C3995EE0039D512 /* Phone.swift in Sources */,
 				82F315DB1C38538100CEFE92 /* Mail.swift in Sources */,
 				54D5D0041C3995EE0039D512 /* Linkedin.swift in Sources */,
+				548042211C3A5AF500BBE49E /* OneDrive.swift in Sources */,
 				82F315CC1C38538100CEFE92 /* Ibooks.swift in Sources */,
 				82F315E71C38538100CEFE92 /* Quora.swift in Sources */,
 				8254C7B51C260DA8009DB3BD /* Path.swift in Sources */,
 				8254C7B71C260DA8009DB3BD /* ExternalApplication.swift in Sources */,
+				548042251C3A5AFE00BBE49E /* Sonos.swift in Sources */,
 				82F315FC1C38538100CEFE92 /* Yelp.swift in Sources */,
 				82F315B11C38538100CEFE92 /* Dropbox.swift in Sources */,
 				8254C7B91C260DA8009DB3BD /* NSExtensionContext+ApplicationCaller.swift in Sources */,
+				548042221C3A5AF700BBE49E /* Outlook.swift in Sources */,
 				54D5CFFE1C3995EE0039D512 /* GoogleChrome.swift in Sources */,
 				82F315FF1C38538100CEFE92 /* Youtube.swift in Sources */,
 				82F315E11C38538100CEFE92 /* Paypal.swift in Sources */,
@@ -912,6 +959,7 @@
 				82F315DE1C38538100CEFE92 /* Messages.swift in Sources */,
 				54D5D0101C3995EE0039D512 /* Remote.swift in Sources */,
 				82F315C91C38538100CEFE92 /* GooglePlus.swift in Sources */,
+				548042241C3A5AFB00BBE49E /* Videos.swift in Sources */,
 				82F315D21C38538100CEFE92 /* INRIXTraffic.swift in Sources */,
 				82F315E41C38538100CEFE92 /* Pinterest.swift in Sources */,
 				82F315F01C38538100CEFE92 /* Tweetbot.swift in Sources */,
@@ -956,6 +1004,7 @@
 				54D5D0051C3995EE0039D512 /* Music.swift in Sources */,
 				82F315B51C38538100CEFE92 /* Facebook.swift in Sources */,
 				54D5D00E1C3995EE0039D512 /* Remote.swift in Sources */,
+				5480421A1C3A5AE300BBE49E /* OneDrive.swift in Sources */,
 				82F315CA1C38538100CEFE92 /* Ibooks.swift in Sources */,
 				82F315C71C38538100CEFE92 /* GooglePlus.swift in Sources */,
 				82F315C11C38538100CEFE92 /* GoogleMail.swift in Sources */,
@@ -963,6 +1012,7 @@
 				82F315D01C38538100CEFE92 /* INRIXTraffic.swift in Sources */,
 				82F315B81C38538100CEFE92 /* FindFriends.swift in Sources */,
 				82F315BB1C38538100CEFE92 /* Flickr.swift in Sources */,
+				5480421B1C3A5AE300BBE49E /* Outlook.swift in Sources */,
 				82F315FA1C38538100CEFE92 /* Yelp.swift in Sources */,
 				8254C7C81C26124D009DB3BD /* NSExtensionContext+ApplicationCaller.swift in Sources */,
 				826ACF191BF1BD1F00B5FC5D /* Applications.swift in Sources */,
@@ -974,12 +1024,14 @@
 				82F315D61C38538100CEFE92 /* Itranslate.swift in Sources */,
 				82F315E51C38538100CEFE92 /* Quora.swift in Sources */,
 				82F315F71C38538100CEFE92 /* WhatsApp.swift in Sources */,
+				5480421D1C3A5AE300BBE49E /* Videos.swift in Sources */,
 				82F315DC1C38538100CEFE92 /* Messages.swift in Sources */,
 				82F315EE1C38538100CEFE92 /* Tweetbot.swift in Sources */,
 				82F315BE1C38538100CEFE92 /* GoogleEarth.swift in Sources */,
 				82F315E81C38538100CEFE92 /* Settings.swift in Sources */,
 				54D5CFFC1C3995EE0039D512 /* GoogleChrome.swift in Sources */,
 				82F315D91C38538100CEFE92 /* Mail.swift in Sources */,
+				5480421C1C3A5AE300BBE49E /* Sonos.swift in Sources */,
 				54D5D0111C3995EE0039D512 /* ScannerPro.swift in Sources */,
 				82F315EB1C38538100CEFE92 /* Telegram.swift in Sources */,
 				54D5D00B1C3995EE0039D512 /* RemindersApp.swift in Sources */,
@@ -1005,11 +1057,13 @@
 				82F316551C38539F00CEFE92 /* ViberTests.swift in Sources */,
 				82F316251C38539F00CEFE92 /* DocumentsTests.swift in Sources */,
 				82F316231C38539F00CEFE92 /* DayOneTests.swift in Sources */,
+				54244A1C1C3A5B7F00AA064F /* OneDriveTests.swift in Sources */,
 				82F316291C38539F00CEFE92 /* EbayTests.swift in Sources */,
 				82F316491C38539F00CEFE92 /* PinterestTests.swift in Sources */,
 				8254C7791C24B515009DB3BD /* PathTests.swift in Sources */,
 				82F316311C38539F00CEFE92 /* GoogleEarthTests.swift in Sources */,
 				82F316271C38539F00CEFE92 /* DropboxTests.swift in Sources */,
+				54244A1F1C3A5B8B00AA064F /* VideosTests.swift in Sources */,
 				82F316371C38539F00CEFE92 /* GooglePlusTests.swift in Sources */,
 				82F316451C38539F00CEFE92 /* MessagesTest.swift in Sources */,
 				82F316511C38539F00CEFE92 /* TweetbotTests.swift in Sources */,
@@ -1025,6 +1079,7 @@
 				5467388D1C3996A200AA42F1 /* GoogleDriveTests.swift in Sources */,
 				546738971C3996A200AA42F1 /* RemoteTests.swift in Sources */,
 				82F3162B1C38539F00CEFE92 /* FacebookTests.swift in Sources */,
+				54244A1E1C3A5B8700AA064F /* SonosTests.swift in Sources */,
 				82F3163D1C38539F00CEFE92 /* INRIXTrafficTests.swift in Sources */,
 				546738991C3996A200AA42F1 /* ScannerProTests.swift in Sources */,
 				82F316531C38539F00CEFE92 /* TwitterTests.swift in Sources */,
@@ -1040,6 +1095,7 @@
 				82F3162D1C38539F00CEFE92 /* FindFriendsTests.swift in Sources */,
 				5467389B1C3996A200AA42F1 /* SkypeTests.swift in Sources */,
 				8246C8D51C1F9B0800569119 /* ApplicationCallerTests.swift in Sources */,
+				54244A1D1C3A5B8300AA064F /* OutlookTests.swift in Sources */,
 				546738931C3996A200AA42F1 /* PhoneTests.swift in Sources */,
 				5467388F1C3996A200AA42F1 /* LinkedinTests.swift in Sources */,
 			);

--- a/Appz/Appz/Apps/Excel.swift
+++ b/Appz/Appz/Apps/Excel.swift
@@ -1,0 +1,47 @@
+//
+//  Excel.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Excel: ExternalApplication {
+        
+        public typealias ActionType = Applications.Excel.Action
+        
+        public let scheme = "ms-excel:"
+        public let fallbackURL = "https://www.office.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Excel {
+    
+    public enum Action {
+        case Open(payload: MSPayload)
+    }
+}
+
+extension Applications.Excel.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open(let payload):
+            
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["ofe\(payload.buildURL())"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/MSPayload.swift
+++ b/Appz/Appz/Apps/MSPayload.swift
@@ -1,0 +1,25 @@
+//
+//  MSPayload.swift
+//  Pods
+//
+//  Created by Mazyad Alabduljaleel on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public struct MSPayload {
+    
+    public var url: String
+    
+    public init(url: String = "") {
+        
+        self.url = url
+    }
+    
+    public func buildURL() -> String {
+        
+        let sections = [("u", url)]
+        
+        // convert tuples to "|x|string", then join them
+        return sections.map { "|\($0.0)|\($0.1)" }.joinWithSeparator("")
+    }
+}

--- a/Appz/Appz/Apps/Mail.swift
+++ b/Appz/Appz/Apps/Mail.swift
@@ -25,7 +25,7 @@ public struct Email {
     var subject: String
     var body: String
     
-    init(recipient: String = "", subject: String = "", body: String = "") {
+    public init(recipient: String = "", subject: String = "", body: String = "") {
         
         self.recipient = recipient
         self.subject = subject

--- a/Appz/Appz/Apps/OneDrive.swift
+++ b/Appz/Appz/Apps/OneDrive.swift
@@ -1,0 +1,46 @@
+//
+//  OneDrive.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct OneDrive: ExternalApplication {
+        
+        public typealias ActionType = Applications.OneDrive.Action
+        
+        public let scheme = "ms-onedrive:"
+        public let fallbackURL = "https://onedrive.live.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.OneDrive {
+    
+    public enum Action {
+        case Open
+    }
+}
+
+extension Applications.OneDrive.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/OneNote.swift
+++ b/Appz/Appz/Apps/OneNote.swift
@@ -1,0 +1,47 @@
+//
+//  OneNote.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/3/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct OneNote: ExternalApplication {
+        
+        public typealias ActionType = Applications.OneNote.Action
+        
+        public let scheme = "onenote:"
+        public let fallbackURL = "https://www.office.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.OneNote {
+    
+    public enum Action {
+        case Open(payload: MSPayload)
+    }
+}
+
+extension Applications.OneNote.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open(let payload):
+            
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["ofe\(payload.buildURL())"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/Outlook.swift
+++ b/Appz/Appz/Apps/Outlook.swift
@@ -1,0 +1,59 @@
+//
+//  Outlook.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Outlook: ExternalApplication {
+        
+        public typealias ActionType = Applications.Outlook.Action
+        
+        public let scheme = "ms-outlook:"
+        public let fallbackURL = "http://www.outlook.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Outlook {
+    
+    public enum Action {
+        case Open
+        case Compose(to: String, subject: String)
+    }
+}
+
+extension Applications.Outlook.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+            
+        case .Compose(let to, let subject):
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["compose"],
+                    queryParameters: [
+                        "to": to,
+                        "subject": subject,
+                    ]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/PowerPoint.swift
+++ b/Appz/Appz/Apps/PowerPoint.swift
@@ -1,0 +1,47 @@
+//
+//  PowerPoint.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct PowerPoint: ExternalApplication {
+        
+        public typealias ActionType = Applications.PowerPoint.Action
+        
+        public let scheme = "ms-powerpoint:"
+        public let fallbackURL = "https://www.office.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.PowerPoint {
+    
+    public enum Action {
+        case Open(payload: MSPayload)
+    }
+}
+
+extension Applications.PowerPoint.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open(let payload):
+            
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["ofe\(payload.buildURL())"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/Sonos.swift
+++ b/Appz/Appz/Apps/Sonos.swift
@@ -1,0 +1,46 @@
+//
+//  Sonos.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Sonos: ExternalApplication {
+        
+        public typealias ActionType = Applications.Sonos.Action
+        
+        public let scheme = "sonos:"
+        public let fallbackURL = "http://www.sonos.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Sonos {
+    
+    public enum Action {
+        case Open
+    }
+}
+
+extension Applications.Sonos.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/Videos.swift
+++ b/Appz/Appz/Apps/Videos.swift
@@ -1,0 +1,46 @@
+//
+//  Videos.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/3/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Videos: ExternalApplication {
+        
+        public typealias ActionType = Applications.Videos.Action
+        
+        public let scheme = "videos:"
+        public let fallbackURL = ""
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Videos {
+    
+    public enum Action {
+        case Open
+    }
+}
+
+extension Applications.Videos.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/Appz/Apps/Word.swift
+++ b/Appz/Appz/Apps/Word.swift
@@ -1,0 +1,47 @@
+//
+//  Word.swift
+//  Pods
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2015 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Word: ExternalApplication {
+        
+        public typealias ActionType = Applications.Word.Action
+        
+        public let scheme = "ms-word:"
+        public let fallbackURL = "https://www.office.com/"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Word {
+    
+    public enum Action {
+        case Open(payload: MSPayload)
+    }
+}
+
+extension Applications.Word.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .Open(let payload):
+            
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["ofe\(payload.buildURL())"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/Appz/AppzTests/AppsTests/ExcelTests.swift
+++ b/Appz/AppzTests/AppsTests/ExcelTests.swift
@@ -1,0 +1,34 @@
+//
+//  ExcelTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/5/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class ExcelTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let excel = Applications.Excel()
+        XCTAssertEqual(excel.scheme, "ms-excel:")
+        XCTAssertEqual(excel.fallbackURL, "https://www.office.com/")
+    }
+    
+    func testOpen() {
+        
+        let link = "https://d.docs.live.net/fa74248df401c361/testy/Book.xlsx"
+        let payload = MSPayload(url: link)
+        
+        let action = Applications.Excel.Action.Open(payload:payload)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["ofe\(payload.buildURL())"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Appz/AppzTests/AppsTests/MessagesTest.swift
+++ b/Appz/AppzTests/AppsTests/MessagesTest.swift
@@ -20,7 +20,7 @@ class MessagesTests: XCTestCase {
         XCTAssertEqual(messages.fallbackURL, "")
     }
     
-    func testEmail() {
+    func testSMS() {
         
         let phone = "12345"
         let action = Applications.Messages.Action.SMS(phone: phone)

--- a/Appz/AppzTests/AppsTests/OneDriveTests.swift
+++ b/Appz/AppzTests/AppsTests/OneDriveTests.swift
@@ -1,0 +1,31 @@
+//
+//  OneDriveTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class OneDriveTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let quora = Applications.OneDrive()
+        XCTAssertEqual(quora.scheme, "ms-onedrive:")
+        XCTAssertEqual(quora.fallbackURL, "https://onedrive.live.com/")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.OneDrive.Action.Open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Appz/AppzTests/AppsTests/OneNoteTests.swift
+++ b/Appz/AppzTests/AppsTests/OneNoteTests.swift
@@ -1,0 +1,34 @@
+//
+//  OneNoteTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/5/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class OneNoteTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let excel = Applications.OneNote()
+        XCTAssertEqual(excel.scheme, "onenote:")
+        XCTAssertEqual(excel.fallbackURL, "https://www.office.com/")
+    }
+    
+    func testOpen() {
+        
+        let link = "https://onedrive.live.com/redir.aspx?cid=fa74248df401c361&page=edit&resid=FA74248DF401C361!140"
+        let payload = MSPayload(url: link)
+        
+        let action = Applications.OneNote.Action.Open(payload:payload)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["ofe\(payload.buildURL())"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Appz/AppzTests/AppsTests/OutlookTests.swift
+++ b/Appz/AppzTests/AppsTests/OutlookTests.swift
@@ -1,0 +1,46 @@
+//
+//  OutlookTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class OutlookTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let quora = Applications.Outlook()
+        XCTAssertEqual(quora.scheme, "ms-outlook:")
+        XCTAssertEqual(quora.fallbackURL, "http://www.outlook.com/")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.Outlook.Action.Open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+    
+    func testCompose() {
+        
+        let to = "mrm259@gmail.com"
+        let subject = "Hi"
+        let action = Applications.Outlook.Action.Compose(to: to, subject: subject)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["compose"])
+        XCTAssertEqual(action.paths.app.queryParameters, [
+                                                            "to": to,
+                                                       "subject": subject,
+                                                                            ])
+        XCTAssertEqual(action.paths.web, Path())
+
+    }
+}

--- a/Appz/AppzTests/AppsTests/PowerPointTests.swift
+++ b/Appz/AppzTests/AppsTests/PowerPointTests.swift
@@ -1,0 +1,34 @@
+//
+//  PowerPointTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/5/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class PowerPointTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let excel = Applications.PowerPoint()
+        XCTAssertEqual(excel.scheme, "ms-powerpoint:")
+        XCTAssertEqual(excel.fallbackURL, "https://www.office.com/")
+    }
+    
+    func testOpen() {
+        
+        let link = "https://d.docs.live.net/fa74248df401c361/testy/test.pptx"
+        let payload = MSPayload(url: link)
+        
+        let action = Applications.PowerPoint.Action.Open(payload:payload)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["ofe\(payload.buildURL())"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Appz/AppzTests/AppsTests/SonosTests.swift
+++ b/Appz/AppzTests/AppsTests/SonosTests.swift
@@ -1,0 +1,31 @@
+//
+//  SonosTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class SonosTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let quora = Applications.Sonos()
+        XCTAssertEqual(quora.scheme, "sonos:")
+        XCTAssertEqual(quora.fallbackURL, "http://www.sonos.com/")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.Sonos.Action.Open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Appz/AppzTests/AppsTests/VideosTests.swift
+++ b/Appz/AppzTests/AppsTests/VideosTests.swift
@@ -1,0 +1,31 @@
+//
+//  VideosTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/4/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class VideosTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let quora = Applications.Videos()
+        XCTAssertEqual(quora.scheme, "videos:")
+        XCTAssertEqual(quora.fallbackURL, "")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.Videos.Action.Open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Appz/AppzTests/AppsTests/WordTests.swift
+++ b/Appz/AppzTests/AppsTests/WordTests.swift
@@ -1,0 +1,34 @@
+//
+//  WordTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/5/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class WordTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let excel = Applications.Word()
+        XCTAssertEqual(excel.scheme, "ms-word:")
+        XCTAssertEqual(excel.fallbackURL, "https://www.office.com/")
+    }
+    
+    func testOpen() {
+        
+        let link = "https://d.docs.live.net/fa74248df401c361/fun.docx"
+        let payload = MSPayload(url: link)
+        
+        let action = Applications.Word.Action.Open(payload:payload)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["ofe\(payload.buildURL())"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ App | Actions
 [Documents][Documents-link] | Open
 [Dropbox][Dropbox-link] | Open
 [ebay][ebay-link] | Open
+[Excel][Excel-link] | Open
 [Facebook][Facebook-link] | Open, Profile, Notification, Feed
 [FindFriends][FindFriends-link] | Open
 [Flickr][Flickr-link] | Open
@@ -121,10 +122,12 @@ App | Actions
 [Messages][Messages-link] | SMS
 [Music][Music-link] | Open
 [OneDrive][OneDrive-link] | Open
+[OneNote][OneNote-link] | Open
 [Outlook][Outlook-link] | Open, Compose
 [Paypal][Paypal-link] | Open
 [Phone][Phone-link] | Open
 [Pinterest][Pinterest-link] | Open, UserProfile, Search
+[PowerPoint][PowerPoint-link] | Open
 [Quora][Quora-link] | Open
 [RemindersApp][RemindersApp-link] | Open
 [Remote][Remote-link] | Open
@@ -137,6 +140,7 @@ App | Actions
 [Viber][Viber-link] | Open Calls Tab, Open Chats Tab
 [Videos][Videos-link] | Open
 [WhatsApp][WhatsApp-link] | Open
+[Word][Word-link] | Open
 [Yelp][Yelp-link] | Open, Search, Search Location, Search Category, Search Category Location, Business
 [Youtube][Youtube-link] | Open, Open Video
 ## Getting Started
@@ -197,6 +201,7 @@ Appz is released under the MIT license. See LICENSE for details.
 [Documents-link]: https://readdle.com/products/documents
 [Dropbox-link]: https://dropbox.com
 [ebay-link]: http://www.ebay.com
+[Excel-link]: https://www.office.com/
 [Facebook-link]: https://facebook.com
 [FindFriends-link]: http://handleopenurl.com/scheme/find-my-friends
 [Flickr-link]: https://www.flickr.com
@@ -216,10 +221,12 @@ Appz is released under the MIT license. See LICENSE for details.
 [Messages-link]: https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/SMSLinks/SMSLinks.html#//apple_ref/doc/uid/TP40007899-CH7-SW1
 [Music-link]: http://handleopenurl.com/scheme/original-ipod-music-app
 [OneDrive-link]: https://onedrive.live.com/
+[OneNote-link]: https://www.office.com/
 [Outlook-link]: http://www.outlook.com/
 [Paypal-link]: https://paypal.com
 [Phone-link]: https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html
 [Pinterest-link]: https://www.pinterest.com
+[PowerPoint-link]: https://www.office.com/
 [Quora-link]: https://www.quora.com
 [RemindersApp-link]: http://handleopenurl.com/scheme/reminders
 [Remote-link]: http://handleopenurl.com/scheme/remote
@@ -232,5 +239,6 @@ Appz is released under the MIT license. See LICENSE for details.
 [Viber-link]: http://www.viber.com
 [Videos-link]: http://handleopenurl.com/scheme/ipod-video-library
 [WhatsApp-link]: https://www.whatsapp.com
+[Word-link]: https://www.office.com/
 [Yelp-link]: https://m.yelp.com
 [Youtube-link]: https://youtube.com

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ App | Actions
 [Mail][Mail-link] | Compose
 [Messages][Messages-link] | SMS
 [Music][Music-link] | Open
+[OneDrive][OneDrive-link] | Open
+[Outlook][Outlook-link] | Open, Compose
 [Paypal][Paypal-link] | Open
 [Phone][Phone-link] | Open
 [Pinterest][Pinterest-link] | Open, UserProfile, Search
@@ -128,11 +130,13 @@ App | Actions
 [Remote][Remote-link] | Open
 [ScannerPro][ScannerPro-link] | Open
 [Skype][Skype-link] | Open
+[Sonos][Sonos-link] | Open
 [Telegram][Telegram-link] | Open, SMS
 [Tweetbot][Tweetbot-link] | Timeline, Post, Mentions, Lists, Retweets, Favorites, Messages, Status, Search, Profile, Follow, Unfollow, Favorite, Unfavorite, Retweet, List
 [Twitter][Twitter-link] | Status, UserHandle, UserId, List, Post, Search, Timeline, Mentions, Messages
 [Viber][Viber-link] | Open Calls Tab, Open Chats Tab
-[WhatsApp][WhatsApp-link] | Open, Send
+[Videos][Videos-link] | Open
+[WhatsApp][WhatsApp-link] | Open
 [Yelp][Yelp-link] | Open, Search, Search Location, Search Category, Search Category Location, Business
 [Youtube][Youtube-link] | Open, Open Video
 ## Getting Started
@@ -203,7 +207,7 @@ Appz is released under the MIT license. See LICENSE for details.
 [GoogleMaps-link]: https://maps.google.com
 [GooglePlus-link]: https://plus.google.com
 [iBooks-link]: http://handleopenurl.com/?id=694
-[IMDb-link]: http://www.imdb.com
+[IMDb-link]: http://www.imdb.com 
 [INRIXTraffic-link]: http://inrix.com/inrix-traffic-app
 [Instagram-link]: https://instagram.com
 [itranslate-link]: http://itranslateapp.com
@@ -211,6 +215,8 @@ Appz is released under the MIT license. See LICENSE for details.
 [Mail-link]: https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/MailLinks/MailLinks.html#//apple_ref/doc/uid/TP40007899-CH4-SW1
 [Messages-link]: https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/SMSLinks/SMSLinks.html#//apple_ref/doc/uid/TP40007899-CH7-SW1
 [Music-link]: http://handleopenurl.com/scheme/original-ipod-music-app
+[OneDrive-link]: https://onedrive.live.com/
+[Outlook-link]: http://www.outlook.com/
 [Paypal-link]: https://paypal.com
 [Phone-link]: https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html
 [Pinterest-link]: https://www.pinterest.com
@@ -219,10 +225,12 @@ Appz is released under the MIT license. See LICENSE for details.
 [Remote-link]: http://handleopenurl.com/scheme/remote
 [ScannerPro-link]: https://readdle.com/products/scannerpro/
 [Skype-link]: http://www.skype.com/
+[Sonos-link]: http://www.sonos.com/
 [Telegram-link]: https://web.telegram.org
 [Tweetbot-link]: http://tapbots.com/tweetbot
 [Twitter-link]: https://twitter.com
 [Viber-link]: http://www.viber.com
+[Videos-link]: http://handleopenurl.com/scheme/ipod-video-library
 [WhatsApp-link]: https://www.whatsapp.com
 [Yelp-link]: https://m.yelp.com
 [Youtube-link]: https://youtube.com


### PR DESCRIPTION
Salam :)

I added Sonos, Videos, OneDrive, and Outlook. I would like to add more apps for Microsoft I think it will be a great idea do you agree with me?

But the problem is app path I think it not suite with Appz, Do you agree?
This is what I found from documentation:
https://msdn.microsoft.com/en-us/library/office/dn911482.aspx
https://msdn.microsoft.com/it-it/library/office/dn906146.aspx#sectionSection9

I tried to add OneNote, Word, Excel, and PowerPoint all of them opened but they keep showing a warning message that I have to open them with a specific file.

It's easy to do it as I found in the above links, like this:
Schema format:
<Office protocol><open mode>|u|<URL>|p|<passback protocol>|c|<document context>
The following example shows a request to invoke a Word file for editing:
ms-word:ofe|u|https://contoso/Q4/budget.docx|p|clouddrive|c|folderviewQ4

But what should we do with ofe|u| we have instead of it //app, Any suggestions?
Thanks .. 
