### PR TITLE
Update to Swift 2.2 and fix error in Playground

### DIFF
--- a/Appz/Appz/Entity/ExternalApplication.swift
+++ b/Appz/Appz/Entity/ExternalApplication.swift
@@ -11,7 +11,7 @@
  */
 public protocol ExternalApplication {
     
-    typealias ActionType: ExternalApplicationAction
+    associatedtype ActionType: ExternalApplicationAction
     
     var scheme: String { get }
     var fallbackURL: String { get }

--- a/Appz/Appz/Entity/ExternalApplication.swift
+++ b/Appz/Appz/Entity/ExternalApplication.swift
@@ -11,7 +11,11 @@
  */
 public protocol ExternalApplication {
     
+    #if swift(>=2.2)
     associatedtype ActionType: ExternalApplicationAction
+    #else
+    typealias ActionType: ExternalApplicationAction
+    #endif
     
     var scheme: String { get }
     var fallbackURL: String { get }

--- a/Playground/Playground.playground/Contents.swift
+++ b/Playground/Playground.playground/Contents.swift
@@ -33,6 +33,7 @@ extension Applications {
         
         let scheme = "myapp:"
         let fallbackURL = ""
+        let appStoreId = ""
     }
 }
 // Finally, you define the actions your app supports

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a alt="Travis CI" href="https://travis-ci.org/SwiftKitz/Appz">
     <img alt="Version" src="https://travis-ci.org/SwiftKitz/Appz.svg?branch=master" />
   </a>
-  <img alt="Swift" src="https://img.shields.io/badge/swift-2.1-orange.svg" />
+  <img alt="Swift" src="https://img.shields.io/badge/swift-2.2-orange.svg" />
   <img alt="Platforms" src="https://img.shields.io/badge/platform-ios%20%7C%20watchos%20%7C%20tvos-lightgrey.svg" />
   <a alt="Carthage Compatible" href="https://github.com/SwiftKitz/Appz#carthage">
     <img alt="Carthage" src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" />
@@ -68,6 +68,7 @@ extension Applications {
 
         let scheme = "myapp:"
         let fallbackURL = ""
+        let appStoreId = ""
     }
 }
 // Then, you define the actions your app supports


### PR DESCRIPTION
This commit fixes:
- Warning: "Use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead"
- Error in Playground: "Type 'Applications.MyApp' does not conform to protocol 'ExternalApplication'"
