### PR TITLE
Add direction Action for AppleMaps

### DIFF
--- a/Appz/Appz/Apps/AppleMaps.swift
+++ b/Appz/Appz/Apps/AppleMaps.swift
@@ -22,10 +22,15 @@ public extension Applications {
 
 // MARK: - Actions
 
+//Direction mod should be ("d" -> For driving, "w"-> for foot, "r"-> for public transit)
+
 public extension Applications.AppleMaps {
     
     public enum Action {
         case Open
+        case DisplayDirections(saddr: String,
+            daddr: String,
+            directionsmode: String)
     }
 }
 
@@ -39,6 +44,18 @@ extension Applications.AppleMaps.Action: ExternalApplicationAction {
                 app: Path(
                     pathComponents: ["app"],
                     queryParameters: [:]
+                ),
+                web: Path()
+            )
+        case .DisplayDirections(let saddr, let daddr, let directionsmode):
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [
+                        "saddr": saddr,
+                        "daddr": daddr,
+                        "dirflg": directionsmode,
+                    ]
                 ),
                 web: Path()
             )


### PR DESCRIPTION
**AppleMaps** have nice parameters when you want to open it.
Check the available parameters on apple docs [here](https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html)

I only added `DisplayDirections` case, like the GoogleMaps one. But we could add also stuff like: _Search nearby location, show an address..._

Cheers 
