### PR TITLE
Add NavigateToDirection Action for Waze App

### DIFF
--- a/Appz/Appz/Apps/Waze.swift
+++ b/Appz/Appz/Apps/Waze.swift
@@ -45,7 +45,7 @@ extension Applications.Waze.Action: ExternalApplicationAction {
             )
         case .NavigateToDirection(let lat, let lng):
             
-            let ll = "\(lat), \(lng)"
+            let ll = "\(lat),\(lng)"
             return ActionPaths(
                 app: Path(
                     pathComponents: [""],

--- a/Appz/Appz/Apps/Waze.swift
+++ b/Appz/Appz/Apps/Waze.swift
@@ -26,6 +26,7 @@ public extension Applications.Waze {
     
     public enum Action {
         case Open
+        case NavigateToDirection(lat:String, lng:String)
     }
 }
 
@@ -39,6 +40,19 @@ extension Applications.Waze.Action: ExternalApplicationAction {
                 app: Path(
                     pathComponents: ["app"],
                     queryParameters: [:]
+                ),
+                web: Path()
+            )
+        case .NavigateToDirection(let lat, let lng):
+            
+            let ll = "\(lat), \(lng)"
+            return ActionPaths(
+                app: Path(
+                    pathComponents: [""],
+                    queryParameters: [
+                        "ll": ll,
+                        "navigate": "yes",
+                    ]
                 ),
                 web: Path()
             )


### PR DESCRIPTION
Hi again !

Same thing for **Waze**, 

Using `NavigateToDirection` action by specifiying both latitude and longitude as strings

There are some other endpoints when opening Waze:
**examples**
_show on map_: waze://?ll=37.331689,-122.030731&z=10
_navigate_: waze://?ll=37.331689,-122.030731&navigate=yes
_options_: search for address: q=<address search term>
center map to lat / lon: ll=<lat>,<lon>
set zoom (minimum is 6): z=<zoom>
auto start navigation: navigate=yes 
