### PR TITLE
To Swift 3

### DIFF
--- a/Appz/Appz.xcodeproj/project.pbxproj
+++ b/Appz/Appz.xcodeproj/project.pbxproj
@@ -1724,7 +1724,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = kitz;
 				TargetAttributes = {
 					8254C79A1C2609FB009DB3BD = {
@@ -1732,9 +1732,11 @@
 					};
 					826ACEDD1BF1B10A00B5FC5D = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					826ACEE71BF1B10A00B5FC5D = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -2646,6 +2648,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2668,6 +2671,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2717,6 +2721,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2740,6 +2745,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2768,8 +2774,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -2818,8 +2826,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -2841,6 +2851,7 @@
 				PRODUCT_MODULE_NAME = Appz;
 				PRODUCT_NAME = Appz;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2853,7 +2864,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2865,6 +2876,7 @@
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2873,7 +2885,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -2884,7 +2896,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.kitz.Appz;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -2898,6 +2911,7 @@
 				PRODUCT_MODULE_NAME = AppzTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2910,6 +2924,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.kitz.AppzTests;
 				PRODUCT_MODULE_NAME = AppzTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Appz/Appz.xcodeproj/xcshareddata/xcschemes/Appz-ios.xcscheme
+++ b/Appz/Appz.xcodeproj/xcshareddata/xcschemes/Appz-ios.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Appz/Appz.xcodeproj/xcshareddata/xcschemes/Appz-tvos.xcscheme
+++ b/Appz/Appz.xcodeproj/xcshareddata/xcschemes/Appz-tvos.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Appz/Appz.xcodeproj/xcshareddata/xcschemes/Appz-watchos.xcscheme
+++ b/Appz/Appz.xcodeproj/xcshareddata/xcschemes/Appz-watchos.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Appz/Appz/Apps/AirLaunch.swift
+++ b/Appz/Appz/Apps/AirLaunch.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.AirLaunch {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.AirLaunch.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/AliExpress.swift
+++ b/Appz/Appz/Apps/AliExpress.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.AliExpress {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.AliExpress.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/AllCast.swift
+++ b/Appz/Appz/Apps/AllCast.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.AllCast {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.AllCast.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/AppStore.swift
+++ b/Appz/Appz/Apps/AppStore.swift
@@ -26,9 +26,9 @@ public extension Applications.AppStore {
 
     public enum Action {
     
-        case Account(id: String)
-        case App(id: String)
-        case RateApp(id: String)
+        case account(id: String)
+        case app(id: String)
+        case rateApp(id: String)
     }
 }
 
@@ -38,7 +38,7 @@ extension Applications.AppStore.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Account(let id):
+        case .account(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["itunes.apple.com", "developer", "id\(id)"],
@@ -47,7 +47,7 @@ extension Applications.AppStore.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .App(let id):
+        case .app(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["itunes.apple.com", "app","id\(id)"],
@@ -56,7 +56,7 @@ extension Applications.AppStore.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .RateApp(let id):
+        case .rateApp(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["itunes.apple.com", "WebObjects", "MZStore.woa", "wa", "viewContentsUserReviews"],

--- a/Appz/Appz/Apps/AppleMaps.swift
+++ b/Appz/Appz/Apps/AppleMaps.swift
@@ -27,8 +27,8 @@ public extension Applications {
 public extension Applications.AppleMaps {
     
     public enum Action {
-        case Open
-        case DisplayDirections(saddr: String,
+        case open
+        case displayDirections(saddr: String,
             daddr: String,
             directionsmode: String)
     }
@@ -39,7 +39,7 @@ extension Applications.AppleMaps.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -47,7 +47,7 @@ extension Applications.AppleMaps.Action: ExternalApplicationAction {
                 ),
                 web: Path()
             )
-        case .DisplayDirections(let saddr, let daddr, let directionsmode):
+        case .displayDirections(let saddr, let daddr, let directionsmode):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Audible.swift
+++ b/Appz/Appz/Apps/Audible.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Audible {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Audible.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/BNR.swift
+++ b/Appz/Appz/Apps/BNR.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.BNR {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.BNR.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Box.swift
+++ b/Appz/Appz/Apps/Box.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Box {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Box.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Buzzfeed.swift
+++ b/Appz/Appz/Apps/Buzzfeed.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Buzzfeed {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Buzzfeed.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/CNN.swift
+++ b/Appz/Appz/Apps/CNN.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.CNN {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.CNN.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Calendars.swift
+++ b/Appz/Appz/Apps/Calendars.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Calendars {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Calendars.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Camera360.swift
+++ b/Appz/Appz/Apps/Camera360.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Camera360 {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Camera360.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Chromecast.swift
+++ b/Appz/Appz/Apps/Chromecast.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Chromecast {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Chromecast.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/CirclePay.swift
+++ b/Appz/Appz/Apps/CirclePay.swift
@@ -25,9 +25,9 @@ public extension Applications {
 public extension Applications.CirclePay {
 
     public enum Action {
-        case Open
-        case Request
-        case Send
+        case open
+        case request
+        case send
     }
 }
 
@@ -36,10 +36,10 @@ extension Applications.CirclePay.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
 
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths()
 
-        case .Request:
+        case .request:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["request"],
@@ -51,7 +51,7 @@ extension Applications.CirclePay.Action: ExternalApplicationAction {
                 )
             )
 
-        case .Send:
+        case .send:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["send"],

--- a/Appz/Appz/Apps/Clips.swift
+++ b/Appz/Appz/Apps/Clips.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Clips {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Clips.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Cnet.swift
+++ b/Appz/Appz/Apps/Cnet.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Cnet {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Cnet.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Currency.swift
+++ b/Appz/Appz/Apps/Currency.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Currency {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Currency.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/DailyMotion.swift
+++ b/Appz/Appz/Apps/DailyMotion.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.DailyMotion {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.DailyMotion.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/DayCost.swift
+++ b/Appz/Appz/Apps/DayCost.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.DayCost {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.DayCost.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/DayOne.swift
+++ b/Appz/Appz/Apps/DayOne.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.DayOne {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.DayOne.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Diigo.swift
+++ b/Appz/Appz/Apps/Diigo.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Diigo {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Diigo.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Documents.swift
+++ b/Appz/Appz/Apps/Documents.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Documents {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Documents.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Dropbox.swift
+++ b/Appz/Appz/Apps/Dropbox.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Dropbox {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Dropbox.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Ebay.swift
+++ b/Appz/Appz/Apps/Ebay.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Ebay {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Ebay.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Echofon.swift
+++ b/Appz/Appz/Apps/Echofon.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Echofon {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Echofon.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Epson.swift
+++ b/Appz/Appz/Apps/Epson.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Epson {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Epson.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Everypost.swift
+++ b/Appz/Appz/Apps/Everypost.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Everypost {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Everypost.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/EyeEm.swift
+++ b/Appz/Appz/Apps/EyeEm.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.EyeEm {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.EyeEm.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/FRIL.swift
+++ b/Appz/Appz/Apps/FRIL.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.FRIL {
 
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.FRIL.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
 
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Facebook.swift
+++ b/Appz/Appz/Apps/Facebook.swift
@@ -25,12 +25,12 @@ public extension Applications {
 public extension Applications.Facebook {
     
     public enum Action {
-        case Open
-        case Profile
-        case Notifications
-        case Feed
-        case Page(String)
-        case Event(String)
+        case open
+        case profile
+        case notifications
+        case feed
+        case page(String)
+        case event(String)
     }
 }
 
@@ -39,7 +39,7 @@ extension Applications.Facebook.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -48,7 +48,7 @@ extension Applications.Facebook.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Profile:
+        case .profile:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["profile"],
@@ -60,7 +60,7 @@ extension Applications.Facebook.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Notifications:
+        case .notifications:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["notifications"],
@@ -72,7 +72,7 @@ extension Applications.Facebook.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Feed:
+        case .feed:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["feed"],
@@ -84,7 +84,7 @@ extension Applications.Facebook.Action: ExternalApplicationAction {
                 )
             )
         
-        case .Page(let id):
+        case .page(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["page"],
@@ -95,7 +95,7 @@ extension Applications.Facebook.Action: ExternalApplicationAction {
                     queryParameters: [:]
                 )
             )
-        case .Event(let id):
+        case .event(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["event"],

--- a/Appz/Appz/Apps/Feedly.swift
+++ b/Appz/Appz/Apps/Feedly.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Feedly {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Feedly.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/FileApp.swift
+++ b/Appz/Appz/Apps/FileApp.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.FileApp {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.FileApp.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/FindFriends.swift
+++ b/Appz/Appz/Apps/FindFriends.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.FindFriends {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.FindFriends.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Fitbit.swift
+++ b/Appz/Appz/Apps/Fitbit.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Fitbit {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Fitbit.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Flickr.swift
+++ b/Appz/Appz/Apps/Flickr.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Flickr {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Flickr.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Flipboard.swift
+++ b/Appz/Appz/Apps/Flipboard.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Flip­board {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Flip­board.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/FlippsTV.swift
+++ b/Appz/Appz/Apps/FlippsTV.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.FlippsTV {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.FlippsTV.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Foursquare.swift
+++ b/Appz/Appz/Apps/Foursquare.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Foursquare {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Foursquare.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/FriendlySocial.swift
+++ b/Appz/Appz/Apps/FriendlySocial.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.FriendlySocial {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.FriendlySocial.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Gallery.swift
+++ b/Appz/Appz/Apps/Gallery.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Gallery {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Gallery.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Glympse.swift
+++ b/Appz/Appz/Apps/Glympse.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Glympse {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Glympse.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleCalendar.swift
+++ b/Appz/Appz/Apps/GoogleCalendar.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.GoogleCalendar {
     
     public enum Action {
-        case Open
-        case CreateEvent
+        case open
+        case createEvent
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.GoogleCalendar.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -44,7 +44,7 @@ extension Applications.GoogleCalendar.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .CreateEvent:
+        case .createEvent:
             return ActionPaths(
                 app: Path(
                     pathComponents: [""],

--- a/Appz/Appz/Apps/GoogleChrome.swift
+++ b/Appz/Appz/Apps/GoogleChrome.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleChrome {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleChrome.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleDocs.swift
+++ b/Appz/Appz/Apps/GoogleDocs.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleDocs {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleDocs.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleDrive.swift
+++ b/Appz/Appz/Apps/GoogleDrive.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleDrive {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleDrive.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleEarth.swift
+++ b/Appz/Appz/Apps/GoogleEarth.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleEarth {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleEarth.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleMail.swift
+++ b/Appz/Appz/Apps/GoogleMail.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleMail {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleMail.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleMaps.swift
+++ b/Appz/Appz/Apps/GoogleMaps.swift
@@ -25,14 +25,14 @@ public extension Applications {
 public extension Applications.GoogleMaps {
     
     public enum Action {
-        case Open
-        case DisplayDirections(saddr: String,
+        case open
+        case displayDirections(saddr: String,
                                daddr: String,
                       directionsmode: String)
-        case DisplayLocation(center: String,
+        case displayLocation(center: String,
                                zoom: String,
                               views: String)
-        case Search(q: String)
+        case search(q: String)
         
     }
 }
@@ -42,7 +42,7 @@ extension Applications.GoogleMaps.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -51,7 +51,7 @@ extension Applications.GoogleMaps.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .DisplayDirections(let saddr, let daddr, let directionsmode):
+        case .displayDirections(let saddr, let daddr, let directionsmode):
             return ActionPaths(
                 app: Path(
                     pathComponents: [""],
@@ -69,7 +69,7 @@ extension Applications.GoogleMaps.Action: ExternalApplicationAction {
                 )
             )
             
-        case .DisplayLocation(let center, let zoom, let views):
+        case .displayLocation(let center, let zoom, let views):
             return ActionPaths(
                 app: Path(
                     pathComponents: [""],
@@ -87,7 +87,7 @@ extension Applications.GoogleMaps.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Search(let q):
+        case .search(let q):
             return ActionPaths(
                 app: Path(
                     pathComponents: [""],

--- a/Appz/Appz/Apps/GooglePhotos.swift
+++ b/Appz/Appz/Apps/GooglePhotos.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GooglePhotos {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GooglePhotos.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GooglePlus.swift
+++ b/Appz/Appz/Apps/GooglePlus.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GooglePlus {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GooglePlus.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleSheets.swift
+++ b/Appz/Appz/Apps/GoogleSheets.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleSheets {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleSheets.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleSlides.swift
+++ b/Appz/Appz/Apps/GoogleSlides.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleSlides {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleSlides.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GoogleTranslate.swift
+++ b/Appz/Appz/Apps/GoogleTranslate.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GoogleTranslate {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GoogleTranslate.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/GroupeMe.swift
+++ b/Appz/Appz/Apps/GroupeMe.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.GroupeMe {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.GroupeMe.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Heapo.swift
+++ b/Appz/Appz/Apps/Heapo.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Heapo {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Heapo.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/HootSuite.swift
+++ b/Appz/Appz/Apps/HootSuite.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.HootSuite {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.HootSuite.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/IMDb.swift
+++ b/Appz/Appz/Apps/IMDb.swift
@@ -26,16 +26,16 @@ public extension Applications.IMDb {
     
     public enum Action {
         
-        case Open
-        case Search(query: String)
-        case Title(id: String)
-        case Boxoffice
-        case Showtimes
-        case FeatureCS
-        case FeatureBP
-        case FeatureBT
-        case ChartTop
-        case Moviemeter
+        case open
+        case search(query: String)
+        case title(id: String)
+        case boxoffice
+        case showtimes
+        case featureCS
+        case featureBP
+        case featureBT
+        case chartTop
+        case moviemeter
     }
 }
 
@@ -45,7 +45,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -54,7 +54,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Search(let query):
+        case .search(let query):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "find"],
@@ -66,7 +66,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Title(let id):
+        case .title(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "title", id],
@@ -78,7 +78,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Boxoffice:
+        case .boxoffice:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "boxoffice"],
@@ -89,7 +89,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                     queryParameters: [:])
             )
             
-        case .Showtimes:
+        case .showtimes:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "showtimes"],
@@ -101,7 +101,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .FeatureCS:
+        case .featureCS:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "feature", "comingsoon"],
@@ -113,7 +113,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .FeatureBP:
+        case .featureBP:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "feature", "bestpicture"],
@@ -125,7 +125,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .FeatureBT:
+        case .featureBT:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "feature", "borntoday"],
@@ -137,7 +137,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .ChartTop:
+        case .chartTop:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "chart", "top"],
@@ -149,7 +149,7 @@ extension Applications.IMDb.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Moviemeter:
+        case .moviemeter:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "chart", "moviemeter"],

--- a/Appz/Appz/Apps/INRIXTraffic.swift
+++ b/Appz/Appz/Apps/INRIXTraffic.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.INRIXTraffic {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.INRIXTraffic.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Ibooks.swift
+++ b/Appz/Appz/Apps/Ibooks.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Ibooks {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Ibooks.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Instagram.swift
+++ b/Appz/Appz/Apps/Instagram.swift
@@ -25,12 +25,12 @@ public extension Applications {
 public extension Applications.Instagram {
     
     public enum Action {
-        case Open
-        case Camera
-        case Media(id: String)
-        case Username(username: String)
-        case Location(id: String)
-        case Tag(name: String)
+        case open
+        case camera
+        case media(id: String)
+        case username(username: String)
+        case location(id: String)
+        case tag(name: String)
         
     }
 }
@@ -40,7 +40,7 @@ extension Applications.Instagram.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -49,7 +49,7 @@ extension Applications.Instagram.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Camera:
+        case .camera:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["camera"],
@@ -58,7 +58,7 @@ extension Applications.Instagram.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Media(let id):
+        case .media(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["media"],
@@ -70,7 +70,7 @@ extension Applications.Instagram.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Username(let username):
+        case .username(let username):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["user"],
@@ -82,7 +82,7 @@ extension Applications.Instagram.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Location(let id):
+        case .location(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["location"],
@@ -91,7 +91,7 @@ extension Applications.Instagram.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Tag(let tag):
+        case .tag(let tag):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["tag"],

--- a/Appz/Appz/Apps/Instapaper.swift
+++ b/Appz/Appz/Apps/Instapaper.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Instapaper {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Instapaper.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Ishows.swift
+++ b/Appz/Appz/Apps/Ishows.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Ishows {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Ishows.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Itranslate.swift
+++ b/Appz/Appz/Apps/Itranslate.swift
@@ -26,8 +26,8 @@ public extension Applications.Itranslate {
     
     public enum Action {
         
-        case Open
-        case Translate(from: String, to: String, text: String)
+        case open
+        case translate(from: String, to: String, text: String)
     }
 }
 
@@ -37,7 +37,7 @@ extension Applications.Itranslate.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -46,7 +46,7 @@ extension Applications.Itranslate.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Translate(let from, let to, let text):
+        case .translate(let from, let to, let text):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["translate"],

--- a/Appz/Appz/Apps/ItunesU.swift
+++ b/Appz/Appz/Apps/ItunesU.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.ItunesU {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.ItunesU.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/KakaoTalk.swift
+++ b/Appz/Appz/Apps/KakaoTalk.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.KakaoTalk {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.KakaoTalk.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Kayak.swift
+++ b/Appz/Appz/Apps/Kayak.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Kayak {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Kayak.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Keeper.swift
+++ b/Appz/Appz/Apps/Keeper.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Keeper {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Keeper.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Kik.swift
+++ b/Appz/Appz/Apps/Kik.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Kik {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Kik.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/LastPass.swift
+++ b/Appz/Appz/Apps/LastPass.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.LastPass {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.LastPass.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Line.swift
+++ b/Appz/Appz/Apps/Line.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Line {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Line.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Linkedin.swift
+++ b/Appz/Appz/Apps/Linkedin.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Linkedin {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Linkedin.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Mail.swift
+++ b/Appz/Appz/Apps/Mail.swift
@@ -39,7 +39,7 @@ public struct Email {
 public extension Applications.Mail {
     
     public enum Action {
-        case Compose(email: Email)
+        case compose(email: Email)
     }
 }
 
@@ -49,7 +49,7 @@ extension Applications.Mail.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Compose(let email):
+        case .compose(let email):
             return ActionPaths(
                 app: Path(
                     pathComponents: [email.recipient],

--- a/Appz/Appz/Apps/Marktplaats.swift
+++ b/Appz/Appz/Apps/Marktplaats.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Marktplaats {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Marktplaats.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Marvis.swift
+++ b/Appz/Appz/Apps/Marvis.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Marvis {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Marvis.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Meerkat.swift
+++ b/Appz/Appz/Apps/Meerkat.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Meerkat {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Meerkat.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Messages.swift
+++ b/Appz/Appz/Apps/Messages.swift
@@ -26,7 +26,7 @@ public extension Applications.Messages {
     
     public enum Action {
         
-        case SMS(phone: String)
+        case sms(phone: String)
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.Messages.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .SMS(let phone):
+        case .sms(let phone):
             return ActionPaths(
                 app: Path(
                     pathComponents: [phone],

--- a/Appz/Appz/Apps/MobileMouse.swift
+++ b/Appz/Appz/Apps/MobileMouse.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.MobileMouse {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.MobileMouse.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Mopico.swift
+++ b/Appz/Appz/Apps/Mopico.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Mopico {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Mopico.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Moves.swift
+++ b/Appz/Appz/Apps/Moves.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Moves {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Moves.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Music.swift
+++ b/Appz/Appz/Apps/Music.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Music {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Music.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/MyFitnessPal.swift
+++ b/Appz/Appz/Apps/MyFitnessPal.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.MyFitnessPal {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.MyFitnessPal.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/NPORadio.swift
+++ b/Appz/Appz/Apps/NPORadio.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.NPORadio {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.NPORadio.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/NameShark.swift
+++ b/Appz/Appz/Apps/NameShark.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.NameShark {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.NameShark.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Netflix.swift
+++ b/Appz/Appz/Apps/Netflix.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Netflix {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Netflix.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Notes.swift
+++ b/Appz/Appz/Apps/Notes.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Notes {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Notes.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Nunl.swift
+++ b/Appz/Appz/Apps/Nunl.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Nunl {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Nunl.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/OMT.swift
+++ b/Appz/Appz/Apps/OMT.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.OMT {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.OMT.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/OneDrive.swift
+++ b/Appz/Appz/Apps/OneDrive.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.OneDrive {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.OneDrive.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/OnePassword.swift
+++ b/Appz/Appz/Apps/OnePassword.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.OnePassword {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.OnePassword.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Outlook.swift
+++ b/Appz/Appz/Apps/Outlook.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.Outlook {
     
     public enum Action {
-        case Open
-        case Compose(to: String, subject: String)
+        case open
+        case compose(to: String, subject: String)
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.Outlook.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -44,7 +44,7 @@ extension Applications.Outlook.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Compose(let to, let subject):
+        case .compose(let to, let subject):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["compose"],

--- a/Appz/Appz/Apps/Paypal.swift
+++ b/Appz/Appz/Apps/Paypal.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Paypal {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Paypal.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Periscope.swift
+++ b/Appz/Appz/Apps/Periscope.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Periscope {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Periscope.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Phone.swift
+++ b/Appz/Appz/Apps/Phone.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Phone {
     
     public enum Action {
-        case Open(number: String)
+        case open(number: String)
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Phone.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open(let number):
+        case .open(let number):
             return ActionPaths(
                 app: Path(
                     pathComponents: [number],

--- a/Appz/Appz/Apps/PicCollage.swift
+++ b/Appz/Appz/Apps/PicCollage.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.PicCollage {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.PicCollage.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Pinterest.swift
+++ b/Appz/Appz/Apps/Pinterest.swift
@@ -25,9 +25,9 @@ public extension Applications {
 public extension Applications.Pinterest {
     
     public enum Action {
-        case Open
-        case User(name: String)
-        case Search(query: String)
+        case open
+        case user(name: String)
+        case search(query: String)
     }
 }
 
@@ -37,7 +37,7 @@ extension Applications.Pinterest.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -46,7 +46,7 @@ extension Applications.Pinterest.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .User(let name):
+        case .user(let name):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["user", name],
@@ -58,7 +58,7 @@ extension Applications.Pinterest.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Search(let query):
+        case .search(let query):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["search", "pins"],

--- a/Appz/Appz/Apps/Pocket.swift
+++ b/Appz/Appz/Apps/Pocket.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Pocket {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Pocket.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Quora.swift
+++ b/Appz/Appz/Apps/Quora.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Quora {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Quora.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/RIDE.swift
+++ b/Appz/Appz/Apps/RIDE.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.RIDE {
 
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.RIDE.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
 
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Radium.swift
+++ b/Appz/Appz/Apps/Radium.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Radium {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Radium.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/RemindersApp.swift
+++ b/Appz/Appz/Apps/RemindersApp.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.RemindersApp {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.RemindersApp.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Remote.swift
+++ b/Appz/Appz/Apps/Remote.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Remote {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Remote.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Rijnmond.swift
+++ b/Appz/Appz/Apps/Rijnmond.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Rijnmond {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Rijnmond.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/RoboForm.swift
+++ b/Appz/Appz/Apps/RoboForm.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.RoboForm {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.RoboForm.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/RunKeeper.swift
+++ b/Appz/Appz/Apps/RunKeeper.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.RunKeeper {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.RunKeeper.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/SSG2.swift
+++ b/Appz/Appz/Apps/SSG2.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.SSG2 {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.SSG2.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/ScannerPro.swift
+++ b/Appz/Appz/Apps/ScannerPro.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.ScannerPro {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.ScannerPro.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Settings.swift
+++ b/Appz/Appz/Apps/Settings.swift
@@ -28,7 +28,7 @@ public extension Applications {
 public extension Applications.AppSettings {
 
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -37,7 +37,7 @@ extension Applications.AppSettings.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths()
         }
     }

--- a/Appz/Appz/Apps/Simplenote.swift
+++ b/Appz/Appz/Apps/Simplenote.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Simplenote {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Simplenote.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Skype.swift
+++ b/Appz/Appz/Apps/Skype.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Skype {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Skype.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Snapchat.swift
+++ b/Appz/Appz/Apps/Snapchat.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.Snapchat {
     
     public enum Action {
-        case Open
-        case Add(username: String)
+        case open
+        case add(username: String)
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.Snapchat.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -43,7 +43,7 @@ extension Applications.Snapchat.Action: ExternalApplicationAction {
                 ),
                 web: Path()
             )
-        case .Add(let Username):
+        case .add(let Username):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["add", Username],

--- a/Appz/Appz/Apps/Snapseed.swift
+++ b/Appz/Appz/Apps/Snapseed.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Snapseed {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Snapseed.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Songpop2.swift
+++ b/Appz/Appz/Apps/Songpop2.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Songpop2 {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Songpop2.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Sonos.swift
+++ b/Appz/Appz/Apps/Sonos.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Sonos {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Sonos.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Soundflake.swift
+++ b/Appz/Appz/Apps/Soundflake.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Soundflake {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Soundflake.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Spark.swift
+++ b/Appz/Appz/Apps/Spark.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Spark {
     
     public enum Action {
-        case Compose(subject: String, recipient: String)
+        case compose(subject: String, recipient: String)
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Spark.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Compose(let subject, let recipient):
+        case .compose(let subject, let recipient):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["compose"],

--- a/Appz/Appz/Apps/StitcherRadio.swift
+++ b/Appz/Appz/Apps/StitcherRadio.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.StitcherRadio {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.StitcherRadio.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Strava.swift
+++ b/Appz/Appz/Apps/Strava.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Strava {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Strava.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/SubwayKorea.swift
+++ b/Appz/Appz/Apps/SubwayKorea.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.SubwayKorea {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.SubwayKorea.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/SunriseCalendar.swift
+++ b/Appz/Appz/Apps/SunriseCalendar.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.SunriseCalendar {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.SunriseCalendar.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Swarm.swift
+++ b/Appz/Appz/Apps/Swarm.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Swarm {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Swarm.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Tango.swift
+++ b/Appz/Appz/Apps/Tango.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Tango {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Tango.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Ted.swift
+++ b/Appz/Appz/Apps/Ted.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Ted {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Ted.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Telegram.swift
+++ b/Appz/Appz/Apps/Telegram.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.Telegram {
     
     public enum Action {
-        case Open
-        case Msg(message: String, phone: String)
+        case open
+        case msg(message: String, phone: String)
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.Telegram.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -44,7 +44,7 @@ extension Applications.Telegram.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Msg(let message, let phone):
+        case .msg(let message, let phone):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["msg"],

--- a/Appz/Appz/Apps/TestFlight.swift
+++ b/Appz/Appz/Apps/TestFlight.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.TestFlight {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.TestFlight.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Tinder.swift
+++ b/Appz/Appz/Apps/Tinder.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Tinder {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Tinder.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Trello.swift
+++ b/Appz/Appz/Apps/Trello.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Trello {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Trello.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Tubex.swift
+++ b/Appz/Appz/Apps/Tubex.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Tubex {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Tubex.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Tumblr.swift
+++ b/Appz/Appz/Apps/Tumblr.swift
@@ -25,12 +25,12 @@ public extension Applications {
 public extension Applications.Tumblr {
     
     public enum Action {
-        case Open
-        case Dashboard
-        case Explore
-        case Activity
-        case Blog
-        case Tag(tag: String)
+        case open
+        case dashboard
+        case explore
+        case activity
+        case blog
+        case tag(tag: String)
     }
 }
 
@@ -39,7 +39,7 @@ extension Applications.Tumblr.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -48,7 +48,7 @@ extension Applications.Tumblr.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Dashboard:
+        case .dashboard:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["x-callback-url", "dashboard"],
@@ -57,7 +57,7 @@ extension Applications.Tumblr.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Explore:
+        case .explore:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["x-callback-url", "explore"],
@@ -66,7 +66,7 @@ extension Applications.Tumblr.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Activity:
+        case .activity:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["x-callback-url", "activity"],
@@ -75,7 +75,7 @@ extension Applications.Tumblr.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Blog:
+        case .blog:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["x-callback-url", "blog"],
@@ -84,7 +84,7 @@ extension Applications.Tumblr.Action: ExternalApplicationAction {
                 web: Path()
             )
           
-        case .Tag(let tag):
+        case .tag(let tag):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["x-callback-url", "tag"],

--- a/Appz/Appz/Apps/Tweetbot.swift
+++ b/Appz/Appz/Apps/Tweetbot.swift
@@ -52,22 +52,22 @@ public extension Applications {
 public extension Applications.Tweetbot {
     
     public enum Action {
-        case Timeline(screenname: String?)
-        case Mentions(screenname: String?)
-        case Retweets(screenname: String?)
-        case DirectMessages(screenname: String?)
-        case Lists(screenname: String?)
-        case Favorites(screenname: String?)
-        case Search(screenname: String?, query: String?, callbackurl: String?)
-        case Status(screenname: String?, tweetId: String, callbackurl: String?)
-        case UserProfile(screenname: String?, profileScreennameOrId: String, callbackurl: String?)
-        case Post(screenname: String?,text: String?, callbackurl: String?, repliedStatusId: String?)
-        case Follow(screenname: String?, followScreennameOrId: String)
-        case Unfollow(screenname: String?, followScreennameOrId: String)
-        case Favorite(screenname: String?, tweetId: String)
-        case Unfavorite(screenname: String?, tweetId: String)
-        case Retweet(screenname: String?, tweetId: String)
-        case List(screenname: String?, listId: String, callbackurl: String?)
+        case timeline(screenname: String?)
+        case mentions(screenname: String?)
+        case retweets(screenname: String?)
+        case directMessages(screenname: String?)
+        case lists(screenname: String?)
+        case favorites(screenname: String?)
+        case search(screenname: String?, query: String?, callbackurl: String?)
+        case status(screenname: String?, tweetId: String, callbackurl: String?)
+        case userProfile(screenname: String?, profileScreennameOrId: String, callbackurl: String?)
+        case post(screenname: String?,text: String?, callbackurl: String?, repliedStatusId: String?)
+        case follow(screenname: String?, followScreennameOrId: String)
+        case unfollow(screenname: String?, followScreennameOrId: String)
+        case favorite(screenname: String?, tweetId: String)
+        case unfavorite(screenname: String?, tweetId: String)
+        case retweet(screenname: String?, tweetId: String)
+        case list(screenname: String?, listId: String, callbackurl: String?)
     }
 }
 
@@ -77,7 +77,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
         
         switch self {
             //do actions
-        case .Timeline(let screenname):
+        case .timeline(let screenname):
             return ActionPaths(
                 app:
                 Path(
@@ -85,7 +85,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Mentions(let screenname):
+        case .mentions(let screenname):
             return ActionPaths(
                 app:
                 Path(
@@ -93,7 +93,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Retweets(let screenname):
+        case .retweets(let screenname):
             return ActionPaths(
                 app:
                 Path(
@@ -101,7 +101,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .DirectMessages(let screenname):
+        case .directMessages(let screenname):
             return ActionPaths(
                 app:
                 Path(
@@ -109,7 +109,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Lists(let screenname):
+        case .lists(let screenname):
             return ActionPaths(
                 app:
                 Path(
@@ -117,7 +117,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Favorites(let screenname):
+        case .favorites(let screenname):
             return ActionPaths(
                 app:
                 Path(
@@ -125,7 +125,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Search(let screenname, let query, let callbackurl):
+        case .search(let screenname, let query, let callbackurl):
             return ActionPaths(
                 app:
                 Path(
@@ -135,7 +135,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                         "callback_url":callbackurl ?? ""]),
                 web: Path())
             
-        case .Status(let screenname, let tweetId, let callbackurl):
+        case .status(let screenname, let tweetId, let callbackurl):
             return ActionPaths(
                 app:
                 Path(
@@ -143,7 +143,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: ["callback_url":callbackurl ?? ""]),
                 web: Path())
             
-        case .UserProfile(let screenname , let profileScreennameOrId , let callbackurl):
+        case .userProfile(let screenname , let profileScreennameOrId , let callbackurl):
             return ActionPaths(
                 app:
                 Path(
@@ -152,7 +152,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: ["callback_url":callbackurl ?? ""]),
                 web: Path())
             
-        case .Post(let screenname, let text, let callbackurl, let repliedStatusId):
+        case .post(let screenname, let text, let callbackurl, let repliedStatusId):
             return ActionPaths(
                 app:
                 Path(
@@ -163,7 +163,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                         "callback_url":callbackurl ?? ""]),
                 web: Path())
             
-        case .Follow(let screenname, let followScreennameOrId):
+        case .follow(let screenname, let followScreennameOrId):
             return ActionPaths(
                 app:
                 Path(
@@ -171,7 +171,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Unfollow(let screenname, let followScreennameOrId):
+        case .unfollow(let screenname, let followScreennameOrId):
             return ActionPaths(
                 app:
                 Path(
@@ -179,7 +179,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Favorite(let screenname, let tweetId):
+        case .favorite(let screenname, let tweetId):
             return ActionPaths(
                 app:
                 Path(
@@ -187,7 +187,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Unfavorite(let screenname, let tweetId):
+        case .unfavorite(let screenname, let tweetId):
             return ActionPaths(
                 app:
                 Path(
@@ -195,7 +195,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .Retweet(let screenname, let tweetId):
+        case .retweet(let screenname, let tweetId):
             return ActionPaths(
                 app:
                 Path(
@@ -203,7 +203,7 @@ extension Applications.Tweetbot.Action: ExternalApplicationAction {
                     queryParameters: [:]),
                 web: Path())
             
-        case .List(let screenname, let listId, let callbackurl):
+        case .list(let screenname, let listId, let callbackurl):
             return ActionPaths(
                 app:
                 Path(

--- a/Appz/Appz/Apps/Twitter.swift
+++ b/Appz/Appz/Apps/Twitter.swift
@@ -26,15 +26,15 @@ public extension Applications.Twitter {
 
     public enum Action {
     
-        case Status(id: String)
-        case UserHandle(String)
-        case UserId(String)
-        case List(handle: String, slug: String)
-        case Post(message: String, repliedStatusId: String?)
-        case Search(query: String)
-        case Timeline
-        case Mentions
-        case Messages
+        case status(id: String)
+        case userHandle(String)
+        case userId(String)
+        case list(handle: String, slug: String)
+        case post(message: String, repliedStatusId: String?)
+        case search(query: String)
+        case timeline
+        case mentions
+        case messages
     }
 }
 
@@ -43,7 +43,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
 
         switch self {
-        case .Status(let id):
+        case .status(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["status"],
@@ -54,7 +54,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .UserHandle(let handle):
+        case .userHandle(let handle):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["user"],
@@ -66,7 +66,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .UserId(let id):
+        case .userId(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["user"],
@@ -78,7 +78,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Post(let message, let statusId):
+        case .post(let message, let statusId):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["post"],
@@ -96,7 +96,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .List(let handle, let slug):
+        case .list(let handle, let slug):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["list"],
@@ -111,7 +111,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Search(let query):
+        case .search(let query):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["search"],
@@ -123,7 +123,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Timeline:
+        case .timeline:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["timeline"],
@@ -135,7 +135,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Mentions:
+        case .mentions:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["mentions"],
@@ -147,7 +147,7 @@ extension Applications.Twitter.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Messages:
+        case .messages:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["messages"],

--- a/Appz/Appz/Apps/Twitterrific.swift
+++ b/Appz/Appz/Apps/Twitterrific.swift
@@ -26,15 +26,15 @@ public extension Applications {
 public extension Applications.Twitterrific {
     
     public enum Action {
-        case Open
-        case MentionsView
-        case MessagesView
-        case FavoritesView
-        case Search(query: String)
-        case TweetID(id: String)
-        case MessageID(id: String)
-        case Post(message: String)
-        case UserProfile(screenName: String)
+        case open
+        case mentionsView
+        case messagesView
+        case favoritesView
+        case search(query: String)
+        case tweetID(id: String)
+        case messageID(id: String)
+        case post(message: String)
+        case userProfile(screenName: String)
     }
 }
 
@@ -43,7 +43,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -52,7 +52,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .MentionsView:
+        case .mentionsView:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["mentions"],
@@ -61,7 +61,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .MessagesView:
+        case .messagesView:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["messages"],
@@ -70,7 +70,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .FavoritesView:
+        case .favoritesView:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["favorites"],
@@ -79,7 +79,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Search(let query):
+        case .search(let query):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["search"],
@@ -88,7 +88,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .TweetID(let id):
+        case .tweetID(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["tweet"],
@@ -97,7 +97,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .MessageID(let id):
+        case .messageID(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["message"],
@@ -106,7 +106,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Post(let message):
+        case .post(let message):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["post"],
@@ -117,7 +117,7 @@ extension Applications.Twitterrific.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .UserProfile(let screenName):
+        case .userProfile(let screenName):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["profile"],

--- a/Appz/Appz/Apps/Uber.swift
+++ b/Appz/Appz/Apps/Uber.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Uber {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Uber.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Unread.swift
+++ b/Appz/Appz/Apps/Unread.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Unread {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Unread.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Ustream.swift
+++ b/Appz/Appz/Apps/Ustream.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Ustream {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Ustream.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/VIPAccess.swift
+++ b/Appz/Appz/Apps/VIPAccess.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.VIPAccess {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.VIPAccess.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/VSCO.swift
+++ b/Appz/Appz/Apps/VSCO.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.VSCO {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.VSCO.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Viber.swift
+++ b/Appz/Appz/Apps/Viber.swift
@@ -26,8 +26,8 @@ public extension Applications.Viber {
     
     public enum Action {
         
-        case CallsTab
-        case ChatsTab
+        case callsTab
+        case chatsTab
     }
 }
 
@@ -37,7 +37,7 @@ extension Applications.Viber.Action: ExternalApplicationAction {
         
         switch self {
             
-        case .CallsTab:
+        case .callsTab:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["calls"],
@@ -46,7 +46,7 @@ extension Applications.Viber.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .ChatsTab:
+        case .chatsTab:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["chats"],

--- a/Appz/Appz/Apps/Videos.swift
+++ b/Appz/Appz/Apps/Videos.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Videos {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Videos.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Vimeo.swift
+++ b/Appz/Appz/Apps/Vimeo.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Vimeo {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Vimeo.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Vine.swift
+++ b/Appz/Appz/Apps/Vine.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.Vine {
     
     public enum Action {
-        case Open
-        case TimelinesPopular
+        case open
+        case timelinesPopular
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.Vine.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -44,7 +44,7 @@ extension Applications.Vine.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .TimelinesPopular:
+        case .timelinesPopular:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["timelines", "popular"],

--- a/Appz/Appz/Apps/Vox.swift
+++ b/Appz/Appz/Apps/Vox.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Vox {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Vox.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Voxer.swift
+++ b/Appz/Appz/Apps/Voxer.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Voxer {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Voxer.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Waze.swift
+++ b/Appz/Appz/Apps/Waze.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.Waze {
     
     public enum Action {
-        case Open
-        case NavigateToDirection(lat:String, lng:String)
+        case open
+        case navigateToDirection(lat:String, lng:String)
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.Waze.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -43,7 +43,7 @@ extension Applications.Waze.Action: ExternalApplicationAction {
                 ),
                 web: Path()
             )
-        case .NavigateToDirection(let lat, let lng):
+        case .navigateToDirection(let lat, let lng):
             
             let ll = "\(lat),\(lng)"
             return ActionPaths(

--- a/Appz/Appz/Apps/WeChat.swift
+++ b/Appz/Appz/Apps/WeChat.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.WeChat {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.WeChat.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Weibo.swift
+++ b/Appz/Appz/Apps/Weibo.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Weibo {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Weibo.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/WhatsApp.swift
+++ b/Appz/Appz/Apps/WhatsApp.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.WhatsApp {
     
     public enum Action {
-        case Open
-        case Send(abid: String?, text: String)
+        case open
+        case send(abid: String?, text: String)
     }
 }
 
@@ -35,7 +35,7 @@ extension Applications.WhatsApp.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -43,7 +43,7 @@ extension Applications.WhatsApp.Action: ExternalApplicationAction {
                 ),
                 web: Path()
             )
-        case .Send(let abid, let text):
+        case .send(let abid, let text):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["send"],

--- a/Appz/Appz/Apps/Whyd.swift
+++ b/Appz/Appz/Apps/Whyd.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Whyd {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Whyd.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Wikipanion.swift
+++ b/Appz/Appz/Apps/Wikipanion.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Wikipanion {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Wikipanion.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/WordPress.swift
+++ b/Appz/Appz/Apps/WordPress.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.WordPress {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.WordPress.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/YahooWeather.swift
+++ b/Appz/Appz/Apps/YahooWeather.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.YahooWeather {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.YahooWeather.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Yammer.swift
+++ b/Appz/Appz/Apps/Yammer.swift
@@ -25,7 +25,7 @@ public extension Applications {
 public extension Applications.Yammer {
     
     public enum Action {
-        case Open
+        case open
     }
 }
 
@@ -34,7 +34,7 @@ extension Applications.Yammer.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],

--- a/Appz/Appz/Apps/Yelp.swift
+++ b/Appz/Appz/Apps/Yelp.swift
@@ -26,12 +26,12 @@ public extension Applications {
 public extension Applications.Yelp {
     
     public enum Action {
-        case Open
-        case Search(query: String)
-        case SearchLocation(query: String, loc: String)
-        case SearchCategory(cat: String)
-        case SearchCatLoc(loc: String, cat: String)
-        case Business(id: String)
+        case open
+        case search(query: String)
+        case searchLocation(query: String, loc: String)
+        case searchCategory(cat: String)
+        case searchCatLoc(loc: String, cat: String)
+        case business(id: String)
     }
 }
 
@@ -40,7 +40,7 @@ extension Applications.Yelp.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open:
+        case .open:
             return ActionPaths(
                 app: Path(
                     pathComponents: ["app"],
@@ -49,7 +49,7 @@ extension Applications.Yelp.Action: ExternalApplicationAction {
                 web: Path()
             )
             
-        case .Search(let query):
+        case .search(let query):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "search"],
@@ -61,7 +61,7 @@ extension Applications.Yelp.Action: ExternalApplicationAction {
                 )
             )
             
-        case .SearchLocation(let query, let loc):
+        case .searchLocation(let query, let loc):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "search"],
@@ -79,7 +79,7 @@ extension Applications.Yelp.Action: ExternalApplicationAction {
                 )
             )
             
-        case .SearchCategory(let cat):
+        case .searchCategory(let cat):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "search"],
@@ -91,7 +91,7 @@ extension Applications.Yelp.Action: ExternalApplicationAction {
                 )
             )
             
-        case .SearchCatLoc(let loc, let cat):
+        case .searchCatLoc(let loc, let cat):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "search"],
@@ -109,7 +109,7 @@ extension Applications.Yelp.Action: ExternalApplicationAction {
                 )
             )
             
-        case .Business(let id):
+        case .business(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["", "biz", id],

--- a/Appz/Appz/Apps/Youtube.swift
+++ b/Appz/Appz/Apps/Youtube.swift
@@ -25,8 +25,8 @@ public extension Applications {
 public extension Applications.Youtube {
     
     public enum Action {
-        case Open()
-        case Video(id: String)
+        case open()
+        case video(id: String)
     }
 }
 
@@ -35,10 +35,10 @@ extension Applications.Youtube.Action: ExternalApplicationAction {
     public var paths: ActionPaths {
         
         switch self {
-        case .Open():
+        case .open():
             return ActionPaths()
             
-        case .Video(let id):
+        case .video(let id):
             return ActionPaths(
                 app: Path(
                     pathComponents: ["watch"],

--- a/Appz/Appz/Entity/ApplicationCaller.swift
+++ b/Appz/Appz/Entity/ApplicationCaller.swift
@@ -14,35 +14,35 @@ import Foundation
 */
 public protocol ApplicationCaller {
     
-    func canOpenURL(url: NSURL) -> Bool
-    func openURL(url: NSURL) -> Bool
+    func canOpenURL(_ url: URL) -> Bool
+    func openURL(_ url: URL) -> Bool
 }
 
 public extension ApplicationCaller {
     
-    public func canOpen<E: ExternalApplication>(externalApp: E) -> Bool {
+    public func canOpen<E: ExternalApplication>(_ externalApp: E) -> Bool {
 
-        if let baseURL = NSURL(string: externalApp.scheme) {
+        if let baseURL = URL(string: externalApp.scheme) {
             return canOpenURL(baseURL)
         }
         
         return false
     }
     
-    public func open<E: ExternalApplication>(externalApp: E, action: E.ActionType, promptInstall: Bool = false) -> Bool {
+    public func open<E: ExternalApplication>(_ externalApp: E, action: E.ActionType, promptInstall: Bool = false) -> Bool {
         
         let scheme = externalApp.scheme
-        let baseURL = NSURL(string: scheme)
+        let baseURL = URL(string: scheme)
         let paths = action.paths
         
-        if let baseURL = baseURL where canOpenURL(baseURL),
+        if let baseURL = baseURL , canOpenURL(baseURL),
             let url = paths.app.appendToURL(scheme)
         {
             return openURL(url)
         }
         
         if promptInstall && !externalApp.appStoreId.isEmpty {
-            return open(Applications.AppStore(), action: .App(id: externalApp.appStoreId))
+            return open(Applications.AppStore(), action: .app(id: externalApp.appStoreId))
         }
         
         if let url = paths.web.appendToURL(externalApp.fallbackURL) {

--- a/Appz/Appz/Entity/Path.swift
+++ b/Appz/Appz/Entity/Path.swift
@@ -14,9 +14,9 @@ public struct Path {
     public var pathComponents = [String]()
     public var queryParameters = [String:String]()
     
-    public var queryItems: [NSURLQueryItem] {
+    public var queryItems: [URLQueryItem] {
         return queryParameters
-            .map { NSURLQueryItem(name: $0, value: $1) }
+            .map { URLQueryItem(name: $0, value: $1) }
     }
     
     public init() {}
@@ -33,27 +33,27 @@ public struct Path {
      - Parameter baseURL:  The base URL.
      
      */
-    public func appendToURL(baseURL: String) -> NSURL? {
+    public func appendToURL(_ baseURL: String) -> URL? {
         
-        guard let url = NSURL(string: baseURL) else {
+        guard let url = URL(string: baseURL) else {
             return nil
         }
         
-        let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: false)
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
         urlComponents?.queryItems = queryItems.isEmpty ? nil : queryItems
         
         var pathComponents = self.pathComponents
         
-        if let firstPath = pathComponents.first where urlComponents?.host == nil {
+        if let firstPath = pathComponents.first , urlComponents?.host == nil {
             urlComponents?.host = firstPath
             pathComponents = Array(pathComponents.dropFirst())
         }
         
         if !pathComponents.isEmpty {
-            urlComponents?.path = "/" + pathComponents.joinWithSeparator("/")
+            urlComponents?.path = "/" + pathComponents.joined(separator: "/")
         }
         
-        return urlComponents?.URL
+        return urlComponents?.url
     }
 }
 

--- a/Appz/Appz/Extensions/NSExtensionContext+ApplicationCaller.swift
+++ b/Appz/Appz/Extensions/NSExtensionContext+ApplicationCaller.swift
@@ -13,12 +13,12 @@ extension NSExtensionContext: ApplicationCaller {
     
     /** Unconditionally fail to the failover code. See rdar://18107612
      */
-    public func canOpenURL(url: NSURL) -> Bool {
+    public func canOpenURL(_ url: URL) -> Bool {
         return false
     }
     
-    public func openURL(url: NSURL) -> Bool {
-        openURL(url, completionHandler: nil)
+    public func openURL(_ url: URL) -> Bool {
+        open(url, completionHandler: nil)
         return true // maybe use a semaphore instead
     }
 }

--- a/Appz/AppzTests/AppsTests/AirLaunchTests.swift
+++ b/Appz/AppzTests/AppsTests/AirLaunchTests.swift
@@ -22,7 +22,7 @@ class AirLaunchTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.AirLaunch.Action.Open
+        let action = Applications.AirLaunch.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/AliExpressTests.swift
+++ b/Appz/AppzTests/AppsTests/AliExpressTests.swift
@@ -22,7 +22,7 @@ class AliExpressTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.AliExpress.Action.Open
+        let action = Applications.AliExpress.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/AllCastTests.swift
+++ b/Appz/AppzTests/AppsTests/AllCastTests.swift
@@ -22,7 +22,7 @@ class AllCastTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.AllCast.Action.Open
+        let action = Applications.AllCast.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/AppStoreTests.swift
+++ b/Appz/AppzTests/AppsTests/AppStoreTests.swift
@@ -24,7 +24,7 @@ class AppStoreTests: XCTestCase {
     func testOpenApp() {
         
         let appId = "395107915"
-        let action = Applications.AppStore.Action.App(id: appId)
+        let action = Applications.AppStore.Action.app(id: appId)
      
         XCTAssertEqual(action.paths.app.pathComponents, ["itunes.apple.com", "app", "id\(appId)"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -34,7 +34,7 @@ class AppStoreTests: XCTestCase {
     func testOpenAccount() {
         
         let accountId = "395107918"
-        let action = Applications.AppStore.Action.Account(id: accountId)
+        let action = Applications.AppStore.Action.account(id: accountId)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["itunes.apple.com", "developer", "id\(accountId)"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -44,7 +44,7 @@ class AppStoreTests: XCTestCase {
     func testRateApp() {
         
         let appId = "327630330"
-        let action = Applications.AppStore.Action.RateApp(id: appId)
+        let action = Applications.AppStore.Action.rateApp(id: appId)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["itunes.apple.com", "WebObjects", "MZStore.woa", "wa", "viewContentsUserReviews"])
         XCTAssertEqual(action.paths.app.queryParameters, [

--- a/Appz/AppzTests/AppsTests/AppleMapsTests.swift
+++ b/Appz/AppzTests/AppsTests/AppleMapsTests.swift
@@ -22,7 +22,7 @@ class AppleMapsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.AppleMaps.Action.Open
+        let action = Applications.AppleMaps.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/AudibleTests.swift
+++ b/Appz/AppzTests/AppsTests/AudibleTests.swift
@@ -22,7 +22,7 @@ class AudibleTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Audible.Action.Open
+        let action = Applications.Audible.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/BNRTests.swift
+++ b/Appz/AppzTests/AppsTests/BNRTests.swift
@@ -22,7 +22,7 @@ class BNRTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.BNR.Action.Open
+        let action = Applications.BNR.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/BoxTests.swift
+++ b/Appz/AppzTests/AppsTests/BoxTests.swift
@@ -22,7 +22,7 @@ class BoxTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Box.Action.Open
+        let action = Applications.Box.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/BuzzfeedTests.swift
+++ b/Appz/AppzTests/AppsTests/BuzzfeedTests.swift
@@ -22,7 +22,7 @@ class BuzzfeedTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Buzzfeed.Action.Open
+        let action = Applications.Buzzfeed.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/CNNTests.swift
+++ b/Appz/AppzTests/AppsTests/CNNTests.swift
@@ -22,7 +22,7 @@ class CNNTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.CNN.Action.Open
+        let action = Applications.CNN.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/CalendarsTests.swift
+++ b/Appz/AppzTests/AppsTests/CalendarsTests.swift
@@ -22,7 +22,7 @@ class CalendarsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Calendars.Action.Open
+        let action = Applications.Calendars.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/Camera360Tests.swift
+++ b/Appz/AppzTests/AppsTests/Camera360Tests.swift
@@ -22,7 +22,7 @@ class Camera360Tests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Camera360.Action.Open
+        let action = Applications.Camera360.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/ChromecastTests.swift
+++ b/Appz/AppzTests/AppsTests/ChromecastTests.swift
@@ -22,7 +22,7 @@ class ChromecastTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Chromecast.Action.Open
+        let action = Applications.Chromecast.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/CirclePayTests.swift
+++ b/Appz/AppzTests/AppsTests/CirclePayTests.swift
@@ -22,7 +22,7 @@ class CirclePayTests: XCTestCase {
 
     func testOpen() {
 
-        let action = Applications.CirclePay.Action.Open
+        let action = Applications.CirclePay.Action.open
 
         XCTAssertEqual(action.paths.app.pathComponents, [])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class CirclePayTests: XCTestCase {
 
     func testRequest() {
 
-        let action = Applications.CirclePay.Action.Request
+        let action = Applications.CirclePay.Action.request
 
         XCTAssertEqual(action.paths.app.pathComponents, ["request"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -41,7 +41,7 @@ class CirclePayTests: XCTestCase {
 
     func testSend() {
 
-        let action = Applications.CirclePay.Action.Send
+        let action = Applications.CirclePay.Action.send
 
         XCTAssertEqual(action.paths.app.pathComponents, ["send"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/ClipsTests.swift
+++ b/Appz/AppzTests/AppsTests/ClipsTests.swift
@@ -22,7 +22,7 @@ class ClipsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Clips.Action.Open
+        let action = Applications.Clips.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/CnetTests.swift
+++ b/Appz/AppzTests/AppsTests/CnetTests.swift
@@ -22,7 +22,7 @@ class CnetTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Cnet.Action.Open
+        let action = Applications.Cnet.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/CurrencyTests.swift
+++ b/Appz/AppzTests/AppsTests/CurrencyTests.swift
@@ -22,7 +22,7 @@ class CurrencyTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Currency.Action.Open
+        let action = Applications.Currency.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/DailyMotionTests.swift
+++ b/Appz/AppzTests/AppsTests/DailyMotionTests.swift
@@ -22,7 +22,7 @@ class DailyMotionTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.DailyMotion.Action.Open
+        let action = Applications.DailyMotion.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/DayCostTests.swift
+++ b/Appz/AppzTests/AppsTests/DayCostTests.swift
@@ -22,7 +22,7 @@ class DayCostTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.DayCost.Action.Open
+        let action = Applications.DayCost.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/DayOneTests.swift
+++ b/Appz/AppzTests/AppsTests/DayOneTests.swift
@@ -22,7 +22,7 @@ class DayOneTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.DayOne.Action.Open
+        let action = Applications.DayOne.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/DiigoTests.swift
+++ b/Appz/AppzTests/AppsTests/DiigoTests.swift
@@ -22,7 +22,7 @@ class DiigoTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Diigo.Action.Open
+        let action = Applications.Diigo.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/DocumentsTests.swift
+++ b/Appz/AppzTests/AppsTests/DocumentsTests.swift
@@ -22,7 +22,7 @@ class DocumentsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Documents.Action.Open
+        let action = Applications.Documents.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/DropboxTests.swift
+++ b/Appz/AppzTests/AppsTests/DropboxTests.swift
@@ -22,7 +22,7 @@ class DropboxTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Dropbox.Action.Open
+        let action = Applications.Dropbox.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/EbayTests.swift
+++ b/Appz/AppzTests/AppsTests/EbayTests.swift
@@ -22,7 +22,7 @@ class EbayTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Ebay.Action.Open
+        let action = Applications.Ebay.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/EchofonTests.swift
+++ b/Appz/AppzTests/AppsTests/EchofonTests.swift
@@ -22,7 +22,7 @@ class EchofonTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Echofon.Action.Open
+        let action = Applications.Echofon.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/EpsonTests.swift
+++ b/Appz/AppzTests/AppsTests/EpsonTests.swift
@@ -22,7 +22,7 @@ class EpsonTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Epson.Action.Open
+        let action = Applications.Epson.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/EverypostTests.swift
+++ b/Appz/AppzTests/AppsTests/EverypostTests.swift
@@ -22,7 +22,7 @@ class EverypostTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Everypost.Action.Open
+        let action = Applications.Everypost.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/EyeEmTests.swift
+++ b/Appz/AppzTests/AppsTests/EyeEmTests.swift
@@ -22,7 +22,7 @@ class EyeEmTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.EyeEm.Action.Open
+        let action = Applications.EyeEm.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FRILTests.swift
+++ b/Appz/AppzTests/AppsTests/FRILTests.swift
@@ -22,7 +22,7 @@ class FRILTests: XCTestCase {
 
     func testOpen() {
 
-        let action = Applications.Line.Action.Open
+        let action = Applications.Line.Action.open
 
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FacebookTests.swift
+++ b/Appz/AppzTests/AppsTests/FacebookTests.swift
@@ -22,7 +22,7 @@ class FacebookTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Facebook.Action.Open
+        let action = Applications.Facebook.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class FacebookTests: XCTestCase {
     
     func testProfile() {
         
-        let action = Applications.Facebook.Action.Profile
+        let action = Applications.Facebook.Action.profile
         
         XCTAssertEqual(action.paths.app.pathComponents, ["profile"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -40,7 +40,7 @@ class FacebookTests: XCTestCase {
     
     func testNotifications() {
         
-        let action = Applications.Facebook.Action.Notifications
+        let action = Applications.Facebook.Action.notifications
         
         XCTAssertEqual(action.paths.app.pathComponents, ["notifications"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -49,7 +49,7 @@ class FacebookTests: XCTestCase {
     
     func testFeed() {
         
-        let action = Applications.Facebook.Action.Feed
+        let action = Applications.Facebook.Action.feed
         
         XCTAssertEqual(action.paths.app.pathComponents, ["feed"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -59,7 +59,7 @@ class FacebookTests: XCTestCase {
     func testPage() {
  
         let pageId = "1524770847774320"
-        let action = Applications.Facebook.Action.Page(pageId)
+        let action = Applications.Facebook.Action.page(pageId)
  
         XCTAssertEqual(action.paths.app.pathComponents, ["page"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id": pageId])
@@ -70,7 +70,7 @@ class FacebookTests: XCTestCase {
     func testEvent() {
         
         let eventId = "1016610545092462"
-        let action = Applications.Facebook.Action.Event(eventId)
+        let action = Applications.Facebook.Action.event(eventId)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["event"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id": eventId])

--- a/Appz/AppzTests/AppsTests/FeedlyTests.swift
+++ b/Appz/AppzTests/AppsTests/FeedlyTests.swift
@@ -22,7 +22,7 @@ class FeedlyTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Feedly.Action.Open
+        let action = Applications.Feedly.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FileAppTests.swift
+++ b/Appz/AppzTests/AppsTests/FileAppTests.swift
@@ -22,7 +22,7 @@ class FileAppTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.FileApp.Action.Open
+        let action = Applications.FileApp.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FindFriendsTests.swift
+++ b/Appz/AppzTests/AppsTests/FindFriendsTests.swift
@@ -22,7 +22,7 @@ class FindFriendsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.FindFriends.Action.Open
+        let action = Applications.FindFriends.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FitbitTests.swift
+++ b/Appz/AppzTests/AppsTests/FitbitTests.swift
@@ -22,7 +22,7 @@ class FitbitTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Fitbit.Action.Open
+        let action = Applications.Fitbit.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FlickrTests.swift
+++ b/Appz/AppzTests/AppsTests/FlickrTests.swift
@@ -22,7 +22,7 @@ class FlickrTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Flickr.Action.Open
+        let action = Applications.Flickr.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FlippsTVTests.swift
+++ b/Appz/AppzTests/AppsTests/FlippsTVTests.swift
@@ -22,7 +22,7 @@ class FlippsTVTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.FlippsTV.Action.Open
+        let action = Applications.FlippsTV.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/Flip­boardTests.swift
+++ b/Appz/AppzTests/AppsTests/Flip­boardTests.swift
@@ -22,7 +22,7 @@ class Flip­boardTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Flip­board.Action.Open
+        let action = Applications.Flip­board.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FoursquareTests.swift
+++ b/Appz/AppzTests/AppsTests/FoursquareTests.swift
@@ -22,7 +22,7 @@ class FoursquareTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Foursquare.Action.Open
+        let action = Applications.Foursquare.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/FriendlySocialTests.swift
+++ b/Appz/AppzTests/AppsTests/FriendlySocialTests.swift
@@ -22,7 +22,7 @@ class FriendlySocialTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.FriendlySocial.Action.Open
+        let action = Applications.FriendlySocial.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GalleryTests.swift
+++ b/Appz/AppzTests/AppsTests/GalleryTests.swift
@@ -22,7 +22,7 @@ class GalleryTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Gallery.Action.Open
+        let action = Applications.Gallery.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GlympseTests.swift
+++ b/Appz/AppzTests/AppsTests/GlympseTests.swift
@@ -22,7 +22,7 @@ class GlympseTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Glympse.Action.Open
+        let action = Applications.Glympse.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleCalendarTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleCalendarTests.swift
@@ -22,7 +22,7 @@ class GoogleCalendarTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleCalendar.Action.Open
+        let action = Applications.GoogleCalendar.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class GoogleCalendarTests: XCTestCase {
     
     func testCreateEvent() {
         
-        let action = Applications.GoogleCalendar.Action.CreateEvent
+        let action = Applications.GoogleCalendar.Action.createEvent
         
         XCTAssertEqual(action.paths.app.pathComponents, [""])
         XCTAssertEqual(action.paths.app.queryParameters, ["action":"create",])

--- a/Appz/AppzTests/AppsTests/GoogleChromeTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleChromeTests.swift
@@ -22,7 +22,7 @@ class GoogleChromeTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleChrome.Action.Open
+        let action = Applications.GoogleChrome.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleDocsTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleDocsTests.swift
@@ -22,7 +22,7 @@ class GoogleDocsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleDocs.Action.Open
+        let action = Applications.GoogleDocs.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleDriveTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleDriveTests.swift
@@ -22,7 +22,7 @@ class GoogleDriveTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleDrive.Action.Open
+        let action = Applications.GoogleDrive.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleEarthTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleEarthTests.swift
@@ -22,7 +22,7 @@ class GoogleEarthTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleEarth.Action.Open
+        let action = Applications.GoogleEarth.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleMailTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleMailTests.swift
@@ -22,7 +22,7 @@ class GoogleMailTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleMail.Action.Open
+        let action = Applications.GoogleMail.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleMapsTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleMapsTests.swift
@@ -22,7 +22,7 @@ class GoogleMapsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleMaps.Action.Open
+        let action = Applications.GoogleMaps.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -34,7 +34,7 @@ class GoogleMapsTests: XCTestCase {
         let saddr = "Surra"
         let daddr = "infocenter"
         let directionsmode = "driving"
-        let action = Applications.GoogleMaps.Action.DisplayDirections(
+        let action = Applications.GoogleMaps.Action.displayDirections(
                                                                     saddr: saddr,
                                                                     daddr: daddr,
                                                                     directionsmode:
@@ -62,7 +62,7 @@ class GoogleMapsTests: XCTestCase {
         let center = "40.765819,-73.975866"
         let zoom = "14"
         let views = "satellite"
-        let action = Applications.GoogleMaps.Action.DisplayLocation(
+        let action = Applications.GoogleMaps.Action.displayLocation(
             center: center,
               zoom: zoom,
              views: views)
@@ -87,7 +87,7 @@ class GoogleMapsTests: XCTestCase {
     func testSearch() {
         
         let q = "Pizza"
-        let action = Applications.GoogleMaps.Action.Search(q: q)
+        let action = Applications.GoogleMaps.Action.search(q: q)
         
         XCTAssertEqual(action.paths.app.pathComponents, [""])
         XCTAssertEqual(action.paths.app.queryParameters, ["q": q,])

--- a/Appz/AppzTests/AppsTests/GooglePhotosTests.swift
+++ b/Appz/AppzTests/AppsTests/GooglePhotosTests.swift
@@ -22,7 +22,7 @@ class GooglePhotosTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GooglePhotos.Action.Open
+        let action = Applications.GooglePhotos.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GooglePlusTests.swift
+++ b/Appz/AppzTests/AppsTests/GooglePlusTests.swift
@@ -22,7 +22,7 @@ class GooglePlusTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GooglePlus.Action.Open
+        let action = Applications.GooglePlus.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleSheetsTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleSheetsTests.swift
@@ -22,7 +22,7 @@ class GoogleSheetsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleSheets.Action.Open
+        let action = Applications.GoogleSheets.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleSlidesTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleSlidesTests.swift
@@ -22,7 +22,7 @@ class GoogleSlidesTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleSlides.Action.Open
+        let action = Applications.GoogleSlides.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GoogleTranslateTests.swift
+++ b/Appz/AppzTests/AppsTests/GoogleTranslateTests.swift
@@ -22,7 +22,7 @@ class GoogleTranslateTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GoogleTranslate.Action.Open
+        let action = Applications.GoogleTranslate.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/GroupeMeTests.swift
+++ b/Appz/AppzTests/AppsTests/GroupeMeTests.swift
@@ -22,7 +22,7 @@ class GroupeMeTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.GroupeMe.Action.Open
+        let action = Applications.GroupeMe.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/HeapoTests.swift
+++ b/Appz/AppzTests/AppsTests/HeapoTests.swift
@@ -22,7 +22,7 @@ class HeapoTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Heapo.Action.Open
+        let action = Applications.Heapo.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/HootSuiteTests.swift
+++ b/Appz/AppzTests/AppsTests/HootSuiteTests.swift
@@ -22,7 +22,7 @@ class HootSuiteTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.HootSuite.Action.Open
+        let action = Applications.HootSuite.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/IMDbTests.swift
+++ b/Appz/AppzTests/AppsTests/IMDbTests.swift
@@ -22,7 +22,7 @@ class IMDbTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.IMDb.Action.Open
+        let action = Applications.IMDb.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -32,7 +32,7 @@ class IMDbTests: XCTestCase {
     func testSearch() {
         
         let query = "baby day out"
-        let action = Applications.IMDb.Action.Search(query: query)
+        let action = Applications.IMDb.Action.search(query: query)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "find"])
         XCTAssertEqual(action.paths.app.queryParameters, ["q":query])
@@ -43,7 +43,7 @@ class IMDbTests: XCTestCase {
     func testTitle() {
         
         let id = "tt0068646"
-        let action = Applications.IMDb.Action.Title(id: id)
+        let action = Applications.IMDb.Action.title(id: id)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "title", id])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -53,7 +53,7 @@ class IMDbTests: XCTestCase {
     
     func testBoxoffice() {
         
-        let action = Applications.IMDb.Action.Boxoffice
+        let action = Applications.IMDb.Action.boxoffice
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "boxoffice"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -63,7 +63,7 @@ class IMDbTests: XCTestCase {
     
     func testShowtimes() {
         
-        let action = Applications.IMDb.Action.Showtimes
+        let action = Applications.IMDb.Action.showtimes
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "showtimes"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -73,7 +73,7 @@ class IMDbTests: XCTestCase {
     
     func testFeatureCS() {
         
-        let action = Applications.IMDb.Action.FeatureCS
+        let action = Applications.IMDb.Action.featureCS
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "feature", "comingsoon"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -83,7 +83,7 @@ class IMDbTests: XCTestCase {
     
     func testFeatureBP() {
         
-        let action = Applications.IMDb.Action.FeatureBP
+        let action = Applications.IMDb.Action.featureBP
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "feature", "bestpicture"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -93,7 +93,7 @@ class IMDbTests: XCTestCase {
     
     func testFeatureBT() {
         
-        let action = Applications.IMDb.Action.FeatureBT
+        let action = Applications.IMDb.Action.featureBT
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "feature", "borntoday"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -103,7 +103,7 @@ class IMDbTests: XCTestCase {
     
     func testChartTop() {
         
-        let action = Applications.IMDb.Action.ChartTop
+        let action = Applications.IMDb.Action.chartTop
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "chart", "top"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -113,7 +113,7 @@ class IMDbTests: XCTestCase {
     
     func testMoviemeter() {
         
-        let action = Applications.IMDb.Action.Moviemeter
+        let action = Applications.IMDb.Action.moviemeter
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "chart", "moviemeter"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/INRIXTrafficTests.swift
+++ b/Appz/AppzTests/AppsTests/INRIXTrafficTests.swift
@@ -22,7 +22,7 @@ class INRIXTrafficTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.INRIXTraffic.Action.Open
+        let action = Applications.INRIXTraffic.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/IbooksTests.swift
+++ b/Appz/AppzTests/AppsTests/IbooksTests.swift
@@ -22,7 +22,7 @@ class IbooksTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Ibooks.Action.Open
+        let action = Applications.Ibooks.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/InstagramTests.swift
+++ b/Appz/AppzTests/AppsTests/InstagramTests.swift
@@ -22,7 +22,7 @@ class InstagramTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Instagram.Action.Open
+        let action = Applications.Instagram.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class InstagramTests: XCTestCase {
     
     func testCamera() {
         
-        let action = Applications.Instagram.Action.Camera
+        let action = Applications.Instagram.Action.camera
         
         XCTAssertEqual(action.paths.app.pathComponents, ["camera"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -40,7 +40,7 @@ class InstagramTests: XCTestCase {
     
     func testMedia() {
         
-        let action = Applications.Instagram.Action.Media(id: "1")
+        let action = Applications.Instagram.Action.media(id: "1")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["media"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id":"1"])
@@ -49,7 +49,7 @@ class InstagramTests: XCTestCase {
     
     func testUsername() {
         
-        let action = Applications.Instagram.Action.Username(username: "test")
+        let action = Applications.Instagram.Action.username(username: "test")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["user"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id":"test"])
@@ -58,7 +58,7 @@ class InstagramTests: XCTestCase {
     
     func testLocation() {
         
-        let action = Applications.Instagram.Action.Location(id: "111")
+        let action = Applications.Instagram.Action.location(id: "111")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["location"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id":"111"])
@@ -67,7 +67,7 @@ class InstagramTests: XCTestCase {
     
     func testTag() {
         
-        let action = Applications.Instagram.Action.Tag(name: "tag")
+        let action = Applications.Instagram.Action.tag(name: "tag")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["tag"])
         XCTAssertEqual(action.paths.app.queryParameters, ["name":"tag"])

--- a/Appz/AppzTests/AppsTests/InstapaperTests.swift
+++ b/Appz/AppzTests/AppsTests/InstapaperTests.swift
@@ -22,7 +22,7 @@ class InstapaperTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Instapaper.Action.Open
+        let action = Applications.Instapaper.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/IshowsTests.swift
+++ b/Appz/AppzTests/AppsTests/IshowsTests.swift
@@ -22,7 +22,7 @@ class IshowsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Ishows.Action.Open
+        let action = Applications.Ishows.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/ItranslateTests.swift
+++ b/Appz/AppzTests/AppsTests/ItranslateTests.swift
@@ -22,7 +22,7 @@ class ItranslateTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Itranslate.Action.Open
+        let action = Applications.Itranslate.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -34,7 +34,7 @@ class ItranslateTests: XCTestCase {
         let from = "en"
         let to   = "ar"
         let text = "Hi"
-        let action = Applications.Itranslate.Action.Translate(from: from, to: to, text: text)
+        let action = Applications.Itranslate.Action.translate(from: from, to: to, text: text)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["translate"])
         XCTAssertEqual(action.paths.app.queryParameters, ["from": from,

--- a/Appz/AppzTests/AppsTests/ItunesUTests.swift
+++ b/Appz/AppzTests/AppsTests/ItunesUTests.swift
@@ -22,7 +22,7 @@ class ItunesUTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.ItunesU.Action.Open
+        let action = Applications.ItunesU.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/KakaoTalkTests.swift
+++ b/Appz/AppzTests/AppsTests/KakaoTalkTests.swift
@@ -22,7 +22,7 @@ class KakaoTalkTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.KakaoTalk.Action.Open
+        let action = Applications.KakaoTalk.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/KayakTests.swift
+++ b/Appz/AppzTests/AppsTests/KayakTests.swift
@@ -22,7 +22,7 @@ class KayakTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Kayak.Action.Open
+        let action = Applications.Kayak.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/KeeperTests.swift
+++ b/Appz/AppzTests/AppsTests/KeeperTests.swift
@@ -22,7 +22,7 @@ class KeeperTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Keeper.Action.Open
+        let action = Applications.Keeper.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/KikTests.swift
+++ b/Appz/AppzTests/AppsTests/KikTests.swift
@@ -22,7 +22,7 @@ class KikTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Kik.Action.Open
+        let action = Applications.Kik.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/LastPassTests.swift
+++ b/Appz/AppzTests/AppsTests/LastPassTests.swift
@@ -22,7 +22,7 @@ class LastPassTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.LastPass.Action.Open
+        let action = Applications.LastPass.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/LineTests.swift
+++ b/Appz/AppzTests/AppsTests/LineTests.swift
@@ -22,7 +22,7 @@ class LineTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Line.Action.Open
+        let action = Applications.Line.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/LinkedinTests.swift
+++ b/Appz/AppzTests/AppsTests/LinkedinTests.swift
@@ -22,7 +22,7 @@ class LinkedinTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Linkedin.Action.Open
+        let action = Applications.Linkedin.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MailTests.swift
+++ b/Appz/AppzTests/AppsTests/MailTests.swift
@@ -28,7 +28,7 @@ class MailTests: XCTestCase {
             body: "body"
         )
         
-        let action = Applications.Mail.Action.Compose(email: email)
+        let action = Applications.Mail.Action.compose(email: email)
         
         XCTAssertEqual(action.paths.app.pathComponents, [email.recipient])
         XCTAssertEqual(action.paths.app.queryParameters, ["subject": email.subject, "body": email.body])

--- a/Appz/AppzTests/AppsTests/MarktplaatsTests.swift
+++ b/Appz/AppzTests/AppsTests/MarktplaatsTests.swift
@@ -22,7 +22,7 @@ class MarktplaatsTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Marktplaats.Action.Open
+        let action = Applications.Marktplaats.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MarvisTests.swift
+++ b/Appz/AppzTests/AppsTests/MarvisTests.swift
@@ -22,7 +22,7 @@ class MarvisTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Marvis.Action.Open
+        let action = Applications.Marvis.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MeerkatTests.swift
+++ b/Appz/AppzTests/AppsTests/MeerkatTests.swift
@@ -22,7 +22,7 @@ class MeerkatTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Meerkat.Action.Open
+        let action = Applications.Meerkat.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MessagesTest.swift
+++ b/Appz/AppzTests/AppsTests/MessagesTest.swift
@@ -23,7 +23,7 @@ class MessagesTests: XCTestCase {
     func testSMS() {
         
         let phone = "12345"
-        let action = Applications.Messages.Action.SMS(phone: phone)
+        let action = Applications.Messages.Action.sms(phone: phone)
         
         XCTAssertEqual(action.paths.app.pathComponents, [phone])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MobileMouseTests.swift
+++ b/Appz/AppzTests/AppsTests/MobileMouseTests.swift
@@ -22,7 +22,7 @@ class MobileMouseTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.MobileMouse.Action.Open
+        let action = Applications.MobileMouse.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MopicoTests.swift
+++ b/Appz/AppzTests/AppsTests/MopicoTests.swift
@@ -22,7 +22,7 @@ class MopicoTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Mopico.Action.Open
+        let action = Applications.Mopico.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MovesTests.swift
+++ b/Appz/AppzTests/AppsTests/MovesTests.swift
@@ -22,7 +22,7 @@ class MovesTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Moves.Action.Open
+        let action = Applications.Moves.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MusicTests.swift
+++ b/Appz/AppzTests/AppsTests/MusicTests.swift
@@ -22,7 +22,7 @@ class MusicTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Music.Action.Open
+        let action = Applications.Music.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/MyFitnessPalTests.swift
+++ b/Appz/AppzTests/AppsTests/MyFitnessPalTests.swift
@@ -22,7 +22,7 @@ class MyFitnessPalTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.MyFitnessPal.Action.Open
+        let action = Applications.MyFitnessPal.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/NPORadioTests.swift
+++ b/Appz/AppzTests/AppsTests/NPORadioTests.swift
@@ -22,7 +22,7 @@ class NPORadioTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.NPORadio.Action.Open
+        let action = Applications.NPORadio.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/NameSharkTests.swift
+++ b/Appz/AppzTests/AppsTests/NameSharkTests.swift
@@ -22,7 +22,7 @@ class NameSharkTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.NameShark.Action.Open
+        let action = Applications.NameShark.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/NetflixTests.swift
+++ b/Appz/AppzTests/AppsTests/NetflixTests.swift
@@ -22,7 +22,7 @@ class NetflixTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Netflix.Action.Open
+        let action = Applications.Netflix.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/NotesTests.swift
+++ b/Appz/AppzTests/AppsTests/NotesTests.swift
@@ -22,7 +22,7 @@ class NotesTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Notes.Action.Open
+        let action = Applications.Notes.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/NunlTests.swift
+++ b/Appz/AppzTests/AppsTests/NunlTests.swift
@@ -22,7 +22,7 @@ class NunlTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Nunl.Action.Open
+        let action = Applications.Nunl.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/OMTTests.swift
+++ b/Appz/AppzTests/AppsTests/OMTTests.swift
@@ -22,7 +22,7 @@ class OMTTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.OMT.Action.Open
+        let action = Applications.OMT.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/OneDriveTests.swift
+++ b/Appz/AppzTests/AppsTests/OneDriveTests.swift
@@ -22,7 +22,7 @@ class OneDriveTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.OneDrive.Action.Open
+        let action = Applications.OneDrive.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/OnePasswordTests.swift
+++ b/Appz/AppzTests/AppsTests/OnePasswordTests.swift
@@ -22,7 +22,7 @@ class OnePasswordTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.OnePassword.Action.Open
+        let action = Applications.OnePassword.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/OutlookTests.swift
+++ b/Appz/AppzTests/AppsTests/OutlookTests.swift
@@ -22,7 +22,7 @@ class OutlookTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Outlook.Action.Open
+        let action = Applications.Outlook.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -33,7 +33,7 @@ class OutlookTests: XCTestCase {
         
         let to = "mrm259@gmail.com"
         let subject = "Hi"
-        let action = Applications.Outlook.Action.Compose(to: to, subject: subject)
+        let action = Applications.Outlook.Action.compose(to: to, subject: subject)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["compose"])
         XCTAssertEqual(action.paths.app.queryParameters, [

--- a/Appz/AppzTests/AppsTests/PaypalTests.swift
+++ b/Appz/AppzTests/AppsTests/PaypalTests.swift
@@ -22,7 +22,7 @@ class PaypalTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Paypal.Action.Open
+        let action = Applications.Paypal.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/PeriscopeTests.swift
+++ b/Appz/AppzTests/AppsTests/PeriscopeTests.swift
@@ -22,7 +22,7 @@ class PeriscopeTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Periscope.Action.Open
+        let action = Applications.Periscope.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/PhoneTests.swift
+++ b/Appz/AppzTests/AppsTests/PhoneTests.swift
@@ -23,7 +23,7 @@ class PhoneTests: XCTestCase {
     func testOpen() {
         
         let number = "1-408-555-5555"
-        let action = Applications.Phone.Action.Open(number:number)
+        let action = Applications.Phone.Action.open(number:number)
         
         XCTAssertEqual(action.paths.app.pathComponents, [number])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/PicCollageTests.swift
+++ b/Appz/AppzTests/AppsTests/PicCollageTests.swift
@@ -22,7 +22,7 @@ class PicCollageTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.PicCollage.Action.Open
+        let action = Applications.PicCollage.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/PinterestTests.swift
+++ b/Appz/AppzTests/AppsTests/PinterestTests.swift
@@ -22,7 +22,7 @@ class PinterestTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Pinterest.Action.Open
+        let action = Applications.Pinterest.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -32,7 +32,7 @@ class PinterestTests: XCTestCase {
     func testUser() {
         
         let name = "mariamaljamea"
-        let action = Applications.Pinterest.Action.User(name: name)
+        let action = Applications.Pinterest.Action.user(name: name)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["user", name])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -43,7 +43,7 @@ class PinterestTests: XCTestCase {
     func testSearch() {
         
         let query = "sky"
-        let action = Applications.Pinterest.Action.Search(query: query)
+        let action = Applications.Pinterest.Action.search(query: query)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["search", "pins"])
         XCTAssertEqual(action.paths.app.queryParameters, ["q":query])

--- a/Appz/AppzTests/AppsTests/PocketTests.swift
+++ b/Appz/AppzTests/AppsTests/PocketTests.swift
@@ -22,7 +22,7 @@ class PocketTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Pocket.Action.Open
+        let action = Applications.Pocket.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/QuoraTests.swift
+++ b/Appz/AppzTests/AppsTests/QuoraTests.swift
@@ -22,7 +22,7 @@ class QuoraTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Quora.Action.Open
+        let action = Applications.Quora.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RIDETests.swift
+++ b/Appz/AppzTests/AppsTests/RIDETests.swift
@@ -22,7 +22,7 @@ class RIDETests: XCTestCase {
 
     func testOpen() {
 
-        let action = Applications.Line.Action.Open
+        let action = Applications.Line.Action.open
 
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RadiumTests.swift
+++ b/Appz/AppzTests/AppsTests/RadiumTests.swift
@@ -22,7 +22,7 @@ class RadiumTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Radium.Action.Open
+        let action = Applications.Radium.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RemindersAppTests.swift
+++ b/Appz/AppzTests/AppsTests/RemindersAppTests.swift
@@ -22,7 +22,7 @@ class RemindersAppTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.RemindersApp.Action.Open
+        let action = Applications.RemindersApp.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RemoteTests.swift
+++ b/Appz/AppzTests/AppsTests/RemoteTests.swift
@@ -22,7 +22,7 @@ class RemoteTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Remote.Action.Open
+        let action = Applications.Remote.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RijnmondTests.swift
+++ b/Appz/AppzTests/AppsTests/RijnmondTests.swift
@@ -22,7 +22,7 @@ class RijnmondTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Rijnmond.Action.Open
+        let action = Applications.Rijnmond.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RoboFormTests.swift
+++ b/Appz/AppzTests/AppsTests/RoboFormTests.swift
@@ -22,7 +22,7 @@ class RoboFormTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.RoboForm.Action.Open
+        let action = Applications.RoboForm.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/RunKeeperTests.swift
+++ b/Appz/AppzTests/AppsTests/RunKeeperTests.swift
@@ -22,7 +22,7 @@ class RunKeeperTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.RunKeeper.Action.Open
+        let action = Applications.RunKeeper.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SSG2Tests.swift
+++ b/Appz/AppzTests/AppsTests/SSG2Tests.swift
@@ -22,7 +22,7 @@ class SSG2Tests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.SSG2.Action.Open
+        let action = Applications.SSG2.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/ScannerProTests.swift
+++ b/Appz/AppzTests/AppsTests/ScannerProTests.swift
@@ -22,7 +22,7 @@ class ScannerProTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.ScannerPro.Action.Open
+        let action = Applications.ScannerPro.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SettingsTests.swift
+++ b/Appz/AppzTests/AppsTests/SettingsTests.swift
@@ -23,7 +23,7 @@ class SettingsTests: XCTestCase {
     
     func testOpenHome() {
         
-        let action = Applications.AppSettings.Action.Open
+        let action = Applications.AppSettings.Action.open
         XCTAssertEqual(action.paths.app.pathComponents, [])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
         XCTAssertEqual(action.paths.web, Path())

--- a/Appz/AppzTests/AppsTests/SimplenoteTests.swift
+++ b/Appz/AppzTests/AppsTests/SimplenoteTests.swift
@@ -22,7 +22,7 @@ class SimplenoteTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Simplenote.Action.Open
+        let action = Applications.Simplenote.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SkypeTests.swift
+++ b/Appz/AppzTests/AppsTests/SkypeTests.swift
@@ -22,7 +22,7 @@ class SkypeTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Skype.Action.Open
+        let action = Applications.Skype.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SnapchatTests.swift
+++ b/Appz/AppzTests/AppsTests/SnapchatTests.swift
@@ -22,7 +22,7 @@ class SnapchatTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Snapchat.Action.Open
+        let action = Applications.Snapchat.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class SnapchatTests: XCTestCase {
     
     
     func testAdd(){
-        let action = Applications.Snapchat.Action.Add(username: "username")
+        let action = Applications.Snapchat.Action.add(username: "username")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["add","username"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SnapseedTests.swift
+++ b/Appz/AppzTests/AppsTests/SnapseedTests.swift
@@ -22,7 +22,7 @@ class SnapseedTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Snapseed.Action.Open
+        let action = Applications.Snapseed.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/Songpop2Tests.swift
+++ b/Appz/AppzTests/AppsTests/Songpop2Tests.swift
@@ -22,7 +22,7 @@ class Songpop2Tests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Songpop2.Action.Open
+        let action = Applications.Songpop2.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SonosTests.swift
+++ b/Appz/AppzTests/AppsTests/SonosTests.swift
@@ -22,7 +22,7 @@ class SonosTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Sonos.Action.Open
+        let action = Applications.Sonos.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SoundflakeTests.swift
+++ b/Appz/AppzTests/AppsTests/SoundflakeTests.swift
@@ -22,7 +22,7 @@ class SoundflakeTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Soundflake.Action.Open
+        let action = Applications.Soundflake.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SparkTests.swift
+++ b/Appz/AppzTests/AppsTests/SparkTests.swift
@@ -24,7 +24,7 @@ class SparkTests: XCTestCase {
         
         let subject = "Hi"
         let recipient = "mrm259@gmail.com"
-        let action = Applications.Spark.Action.Compose(subject: subject, recipient:recipient)
+        let action = Applications.Spark.Action.compose(subject: subject, recipient:recipient)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["compose"])
         XCTAssertEqual(action.paths.app.queryParameters, [

--- a/Appz/AppzTests/AppsTests/StitcherRadioTests.swift
+++ b/Appz/AppzTests/AppsTests/StitcherRadioTests.swift
@@ -22,7 +22,7 @@ class StitcherRadioTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.StitcherRadio.Action.Open
+        let action = Applications.StitcherRadio.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/StravaTests.swift
+++ b/Appz/AppzTests/AppsTests/StravaTests.swift
@@ -22,7 +22,7 @@ class StravaTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Strava.Action.Open
+        let action = Applications.Strava.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SubwayKoreaTests.swift
+++ b/Appz/AppzTests/AppsTests/SubwayKoreaTests.swift
@@ -22,7 +22,7 @@ class SubwayKoreaTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.SubwayKorea.Action.Open
+        let action = Applications.SubwayKorea.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SunriseCalendarTests.swift
+++ b/Appz/AppzTests/AppsTests/SunriseCalendarTests.swift
@@ -22,7 +22,7 @@ class SunriseCalendarTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.SunriseCalendar.Action.Open
+        let action = Applications.SunriseCalendar.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/SwarmTests.swift
+++ b/Appz/AppzTests/AppsTests/SwarmTests.swift
@@ -22,7 +22,7 @@ class SwarmTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Swarm.Action.Open
+        let action = Applications.Swarm.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TangoTests.swift
+++ b/Appz/AppzTests/AppsTests/TangoTests.swift
@@ -22,7 +22,7 @@ class TangoTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Tango.Action.Open
+        let action = Applications.Tango.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TedTests.swift
+++ b/Appz/AppzTests/AppsTests/TedTests.swift
@@ -22,7 +22,7 @@ class TedTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Ted.Action.Open
+        let action = Applications.Ted.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TelegramTests.swift
+++ b/Appz/AppzTests/AppsTests/TelegramTests.swift
@@ -24,7 +24,7 @@ class TelegramTests: XCTestCase {
         
         let message = "Hi"
         let phone = "12345" //You must prefix the number with +
-        let action = Applications.Telegram.Action.Msg(message: message, phone: phone)
+        let action = Applications.Telegram.Action.msg(message: message, phone: phone)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["msg"])
         XCTAssertEqual(action.paths.app.queryParameters,

--- a/Appz/AppzTests/AppsTests/TestFlightTests.swift
+++ b/Appz/AppzTests/AppsTests/TestFlightTests.swift
@@ -22,7 +22,7 @@ class TestFlightTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.TestFlight.Action.Open
+        let action = Applications.TestFlight.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TinderTests.swift
+++ b/Appz/AppzTests/AppsTests/TinderTests.swift
@@ -22,7 +22,7 @@ class TinderTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Tinder.Action.Open
+        let action = Applications.Tinder.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TrelloTests.swift
+++ b/Appz/AppzTests/AppsTests/TrelloTests.swift
@@ -22,7 +22,7 @@ class TrelloTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Trello.Action.Open
+        let action = Applications.Trello.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TubexTests.swift
+++ b/Appz/AppzTests/AppsTests/TubexTests.swift
@@ -22,7 +22,7 @@ class TubexTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Tubex.Action.Open
+        let action = Applications.Tubex.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TumblrTests.swift
+++ b/Appz/AppzTests/AppsTests/TumblrTests.swift
@@ -22,7 +22,7 @@ class TumblrTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Tumblr.Action.Open
+        let action = Applications.Tumblr.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class TumblrTests: XCTestCase {
     
     func testDashboard() {
         
-        let action = Applications.Tumblr.Action.Dashboard
+        let action = Applications.Tumblr.Action.dashboard
         
         XCTAssertEqual(action.paths.app.pathComponents,
                                                     ["x-callback-url", "dashboard"])
@@ -41,7 +41,7 @@ class TumblrTests: XCTestCase {
     
     func testExplore() {
         
-        let action = Applications.Tumblr.Action.Explore
+        let action = Applications.Tumblr.Action.explore
         
         XCTAssertEqual(action.paths.app.pathComponents,
                                                     ["x-callback-url", "explore"])
@@ -51,7 +51,7 @@ class TumblrTests: XCTestCase {
     
     func testActivity() {
         
-        let action = Applications.Tumblr.Action.Activity
+        let action = Applications.Tumblr.Action.activity
         
         XCTAssertEqual(action.paths.app.pathComponents,
                                                     ["x-callback-url", "activity"])
@@ -61,7 +61,7 @@ class TumblrTests: XCTestCase {
     
     func testBlog() {
         
-        let action = Applications.Tumblr.Action.Blog
+        let action = Applications.Tumblr.Action.blog
         
         XCTAssertEqual(action.paths.app.pathComponents,
                                                     ["x-callback-url", "blog"])
@@ -72,7 +72,7 @@ class TumblrTests: XCTestCase {
     func testTag() {
         
         let tag = "moon"
-        let action = Applications.Tumblr.Action.Tag(tag: tag)
+        let action = Applications.Tumblr.Action.tag(tag: tag)
         
         XCTAssertEqual(action.paths.app.pathComponents,
                                                     ["x-callback-url", "tag"])

--- a/Appz/AppzTests/AppsTests/TweetbotTests.swift
+++ b/Appz/AppzTests/AppsTests/TweetbotTests.swift
@@ -21,13 +21,13 @@ class TweetbotTests: XCTestCase {
     }
     
     func testTimeline() {
-        var action = Applications.Tweetbot.Action.Timeline(screenname: nil)
+        var action = Applications.Tweetbot.Action.timeline(screenname: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","timeline"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Timeline(screenname: "dreamer_soul")
+        action = Applications.Tweetbot.Action.timeline(screenname: "dreamer_soul")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","timeline"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -38,13 +38,13 @@ class TweetbotTests: XCTestCase {
     
     
     func testMentions() {
-        var action = Applications.Tweetbot.Action.Mentions(screenname: nil)
+        var action = Applications.Tweetbot.Action.mentions(screenname: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","mentions"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Mentions(screenname: "dreamer_soul")
+        action = Applications.Tweetbot.Action.mentions(screenname: "dreamer_soul")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","mentions"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -54,13 +54,13 @@ class TweetbotTests: XCTestCase {
     }
     
     func testDirectMessage() {
-        var action = Applications.Tweetbot.Action.DirectMessages(screenname: nil)
+        var action = Applications.Tweetbot.Action.directMessages(screenname: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","direct_messages"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.DirectMessages(screenname: "dreamer_soul")
+        action = Applications.Tweetbot.Action.directMessages(screenname: "dreamer_soul")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","direct_messages"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -70,13 +70,13 @@ class TweetbotTests: XCTestCase {
     }
     
     func testFavorites() {
-        var action = Applications.Tweetbot.Action.Favorites(screenname: nil)
+        var action = Applications.Tweetbot.Action.favorites(screenname: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","favorites"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Favorites(screenname: "dreamer_soul")
+        action = Applications.Tweetbot.Action.favorites(screenname: "dreamer_soul")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","favorites"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -86,13 +86,13 @@ class TweetbotTests: XCTestCase {
     }
     
     func testRetweets() {
-        var action = Applications.Tweetbot.Action.Retweets(screenname: nil)
+        var action = Applications.Tweetbot.Action.retweets(screenname: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","retweets"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Retweets(screenname: "dreamer_soul")
+        action = Applications.Tweetbot.Action.retweets(screenname: "dreamer_soul")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","retweets"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -102,13 +102,13 @@ class TweetbotTests: XCTestCase {
     }
     
     func testLists() {
-        var action = Applications.Tweetbot.Action.Lists(screenname: nil)
+        var action = Applications.Tweetbot.Action.lists(screenname: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","lists"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Lists(screenname: "dreamer_soul")
+        action = Applications.Tweetbot.Action.lists(screenname: "dreamer_soul")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","lists"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -119,13 +119,13 @@ class TweetbotTests: XCTestCase {
     
     func testFavorite() {
         let id = "someId"
-        var action = Applications.Tweetbot.Action.Favorite(screenname: nil, tweetId: id)
+        var action = Applications.Tweetbot.Action.favorite(screenname: nil, tweetId: id)
         XCTAssertEqual(action.paths.app.pathComponents, ["", "favorite", id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Favorite(screenname: "dreamer_soul", tweetId: id)
+        action = Applications.Tweetbot.Action.favorite(screenname: "dreamer_soul", tweetId: id)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul", "favorite", id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -136,13 +136,13 @@ class TweetbotTests: XCTestCase {
     
     func testUnfavorite(){
         let id = "someId"
-        var action = Applications.Tweetbot.Action.Unfavorite(screenname: nil, tweetId: id)
+        var action = Applications.Tweetbot.Action.unfavorite(screenname: nil, tweetId: id)
         XCTAssertEqual(action.paths.app.pathComponents, ["","unfavorite",id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
-        action = Applications.Tweetbot.Action.Unfavorite(screenname: "dreamer_soul", tweetId: id)
+        action = Applications.Tweetbot.Action.unfavorite(screenname: "dreamer_soul", tweetId: id)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul", "unfavorite", id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
@@ -155,14 +155,14 @@ class TweetbotTests: XCTestCase {
     func testRetweet(){
         let id = "someId"
         
-        var action = Applications.Tweetbot.Action.Retweet(screenname: nil, tweetId: id)
+        var action = Applications.Tweetbot.Action.retweet(screenname: nil, tweetId: id)
         XCTAssertEqual(action.paths.app.pathComponents, ["","retweet",id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.Retweet(screenname: "dreamer_soul", tweetId: id)
+        action = Applications.Tweetbot.Action.retweet(screenname: "dreamer_soul", tweetId: id)
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul", "retweet", id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
@@ -173,14 +173,14 @@ class TweetbotTests: XCTestCase {
     func testFollow(){
         let id = "someId"
         
-        var action = Applications.Tweetbot.Action.Follow(screenname: nil, followScreennameOrId: id)
+        var action = Applications.Tweetbot.Action.follow(screenname: nil, followScreennameOrId: id)
         XCTAssertEqual(action.paths.app.pathComponents, ["","follow",id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.Follow(screenname: "dreamer_soul", followScreennameOrId: id)
+        action = Applications.Tweetbot.Action.follow(screenname: "dreamer_soul", followScreennameOrId: id)
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul", "follow", id])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
@@ -191,14 +191,14 @@ class TweetbotTests: XCTestCase {
     func testList(){
         let id = "someId"
         
-        var action = Applications.Tweetbot.Action.List(screenname: nil, listId: id, callbackurl: nil)
+        var action = Applications.Tweetbot.Action.list(screenname: nil, listId: id, callbackurl: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","list",id])
         XCTAssertEqual(action.paths.app.queryParameters,["callback_url": ""])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.List(screenname: "dreamer_soul", listId: id, callbackurl: "someurl")
+        action = Applications.Tweetbot.Action.list(screenname: "dreamer_soul", listId: id, callbackurl: "someurl")
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul", "list", id])
         XCTAssertEqual(action.paths.app.queryParameters,["callback_url" : "someurl"])
         
@@ -208,14 +208,14 @@ class TweetbotTests: XCTestCase {
     
     func testPost(){
         
-        var action = Applications.Tweetbot.Action.Post(screenname: nil, text: nil, callbackurl: nil, repliedStatusId: nil)
+        var action = Applications.Tweetbot.Action.post(screenname: nil, text: nil, callbackurl: nil, repliedStatusId: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","post"])
         XCTAssertEqual(action.paths.app.queryParameters,["text":"", "in_reply_to_status_id":"", "callback_url": ""])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.Post(screenname: "dreamer_soul", text: "some Tweet Text", callbackurl: "www.google.com", repliedStatusId: "someId")
+        action = Applications.Tweetbot.Action.post(screenname: "dreamer_soul", text: "some Tweet Text", callbackurl: "www.google.com", repliedStatusId: "someId")
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul", "post"])
         XCTAssertEqual(action.paths.app.queryParameters,["text":"some Tweet Text", "in_reply_to_status_id":"someId", "callback_url": "www.google.com"])
         
@@ -226,14 +226,14 @@ class TweetbotTests: XCTestCase {
     
     func testSearch(){
         
-        var action = Applications.Tweetbot.Action.Search(screenname: nil, query: nil, callbackurl: nil)
+        var action = Applications.Tweetbot.Action.search(screenname: nil, query: nil, callbackurl: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","search"])
         XCTAssertEqual(action.paths.app.queryParameters,["query":"", "callback_url": ""])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.Search(screenname: "dreamer_soul", query: "some Tweet Text", callbackurl: "www.google.com")
+        action = Applications.Tweetbot.Action.search(screenname: "dreamer_soul", query: "some Tweet Text", callbackurl: "www.google.com")
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","search"])
         XCTAssertEqual(action.paths.app.queryParameters,["query":"some Tweet Text", "callback_url": "www.google.com"])
         
@@ -242,14 +242,14 @@ class TweetbotTests: XCTestCase {
     }
     
     func testUnfollow(){
-        var action = Applications.Tweetbot.Action.Unfollow(screenname: nil, followScreennameOrId: "9gag")
+        var action = Applications.Tweetbot.Action.unfollow(screenname: nil, followScreennameOrId: "9gag")
         XCTAssertEqual(action.paths.app.pathComponents, ["","unfollow","9gag"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.Unfollow(screenname: "dreamer_soul", followScreennameOrId: "9gag")
+        action = Applications.Tweetbot.Action.unfollow(screenname: "dreamer_soul", followScreennameOrId: "9gag")
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","unfollow", "9gag"])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
@@ -258,14 +258,14 @@ class TweetbotTests: XCTestCase {
     }
     
     func testUserProfile(){
-        var action = Applications.Tweetbot.Action.UserProfile(screenname: nil, profileScreennameOrId: "9gag", callbackurl: nil)
+        var action = Applications.Tweetbot.Action.userProfile(screenname: nil, profileScreennameOrId: "9gag", callbackurl: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","user_profile","9gag"])
         XCTAssertEqual(action.paths.app.queryParameters,["callback_url":""])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.UserProfile(screenname: "dreamer_soul", profileScreennameOrId: "9gag", callbackurl: "www.google.com")
+        action = Applications.Tweetbot.Action.userProfile(screenname: "dreamer_soul", profileScreennameOrId: "9gag", callbackurl: "www.google.com")
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","user_profile", "9gag"])
         XCTAssertEqual(action.paths.app.queryParameters,["callback_url":"www.google.com"])
         
@@ -274,14 +274,14 @@ class TweetbotTests: XCTestCase {
     }
     
     func testStatus(){
-        var action = Applications.Tweetbot.Action.Status(screenname: nil, tweetId: "someId", callbackurl: nil)
+        var action = Applications.Tweetbot.Action.status(screenname: nil, tweetId: "someId", callbackurl: nil)
         XCTAssertEqual(action.paths.app.pathComponents, ["","status","someId"])
         XCTAssertEqual(action.paths.app.queryParameters,["callback_url":""])
         
         XCTAssertEqual(action.paths.web.pathComponents, [])
         XCTAssertEqual(action.paths.web.queryParameters,[:])
         
-        action = Applications.Tweetbot.Action.Status(screenname: "dreamer_soul", tweetId: "someId", callbackurl: "www.google.com")
+        action = Applications.Tweetbot.Action.status(screenname: "dreamer_soul", tweetId: "someId", callbackurl: "www.google.com")
         XCTAssertEqual(action.paths.app.pathComponents, ["dreamer_soul","status", "someId"])
         XCTAssertEqual(action.paths.app.queryParameters,["callback_url":"www.google.com"])
         

--- a/Appz/AppzTests/AppsTests/TwitterTests.swift
+++ b/Appz/AppzTests/AppsTests/TwitterTests.swift
@@ -23,7 +23,7 @@ class TwitterTests: XCTestCase {
     func testStatus() {
         
         let statusId = "663797797234323456"
-        let action = Applications.Twitter.Action.Status(id: statusId)
+        let action = Applications.Twitter.Action.status(id: statusId)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["status"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id": statusId])
@@ -34,7 +34,7 @@ class TwitterTests: XCTestCase {
     func testUserHandle() {
         
         let handle = "mazyod"
-        let action = Applications.Twitter.Action.UserHandle(handle)
+        let action = Applications.Twitter.Action.userHandle(handle)
 
         XCTAssertEqual(action.paths.app.pathComponents, ["user"])
         XCTAssertEqual(action.paths.app.queryParameters, ["screen_name": handle])
@@ -45,7 +45,7 @@ class TwitterTests: XCTestCase {
     func testUserId() {
 
         let userId = "1233456"
-        let action = Applications.Twitter.Action.UserId(userId)
+        let action = Applications.Twitter.Action.userId(userId)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["user"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id": userId])
@@ -57,7 +57,7 @@ class TwitterTests: XCTestCase {
         
         let handle = "mazyod"
         let slug = "test"
-        let action = Applications.Twitter.Action.List(handle: handle, slug: slug)
+        let action = Applications.Twitter.Action.list(handle: handle, slug: slug)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["list"])
         XCTAssertEqual(action.paths.app.queryParameters, [
@@ -72,7 +72,7 @@ class TwitterTests: XCTestCase {
         
         let message = "Releasing Appz v1.0.0!"
         let repliedStatusId = ""
-        let action = Applications.Twitter.Action.Post(message: message, repliedStatusId: nil)
+        let action = Applications.Twitter.Action.post(message: message, repliedStatusId: nil)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["post"])
         XCTAssertEqual(action.paths.app.queryParameters, [
@@ -89,7 +89,7 @@ class TwitterTests: XCTestCase {
     func testSearch() {
         
         let query = "#anon"
-        let action = Applications.Twitter.Action.Search(query: query)
+        let action = Applications.Twitter.Action.search(query: query)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["search"])
         XCTAssertEqual(action.paths.app.queryParameters, ["query":query])
@@ -99,7 +99,7 @@ class TwitterTests: XCTestCase {
     
     func testTimeline() {
         
-        let action = Applications.Twitter.Action.Timeline
+        let action = Applications.Twitter.Action.timeline
         
         XCTAssertEqual(action.paths.app.pathComponents, ["timeline"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -109,7 +109,7 @@ class TwitterTests: XCTestCase {
     
     func testMentions() {
         
-        let action = Applications.Twitter.Action.Mentions
+        let action = Applications.Twitter.Action.mentions
         
         XCTAssertEqual(action.paths.app.pathComponents, ["mentions"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -119,7 +119,7 @@ class TwitterTests: XCTestCase {
     
     func testMessages() {
         
-        let action = Applications.Twitter.Action.Messages
+        let action = Applications.Twitter.Action.messages
         
         XCTAssertEqual(action.paths.app.pathComponents, ["messages"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/TwitterrificTests.swift
+++ b/Appz/AppzTests/AppsTests/TwitterrificTests.swift
@@ -22,7 +22,7 @@ class TwitterrificTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Twitterrific.Action.Open
+        let action = Applications.Twitterrific.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class TwitterrificTests: XCTestCase {
     
     func testMentionsView() {
         
-        let action = Applications.Twitterrific.Action.MentionsView
+        let action = Applications.Twitterrific.Action.mentionsView
         
         XCTAssertEqual(action.paths.app.pathComponents, ["mentions"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -40,7 +40,7 @@ class TwitterrificTests: XCTestCase {
     
     func testMessagesView() {
         
-        let action = Applications.Twitterrific.Action.MessagesView
+        let action = Applications.Twitterrific.Action.messagesView
         
         XCTAssertEqual(action.paths.app.pathComponents, ["messages"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -49,7 +49,7 @@ class TwitterrificTests: XCTestCase {
     
     func testFavoritesView() {
         
-        let action = Applications.Twitterrific.Action.FavoritesView
+        let action = Applications.Twitterrific.Action.favoritesView
         
         XCTAssertEqual(action.paths.app.pathComponents, ["favorites"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -59,7 +59,7 @@ class TwitterrificTests: XCTestCase {
     func testSearch() {
         
         let query = "Hi"
-        let action = Applications.Twitterrific.Action.Search(query: query)
+        let action = Applications.Twitterrific.Action.search(query: query)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["search"])
         XCTAssertEqual(action.paths.app.queryParameters, ["q":query])
@@ -69,7 +69,7 @@ class TwitterrificTests: XCTestCase {
     func testTweetID() {
         
         let id = "12345"
-        let action = Applications.Twitterrific.Action.TweetID(id: id)
+        let action = Applications.Twitterrific.Action.tweetID(id: id)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["tweet"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id":id])
@@ -79,7 +79,7 @@ class TwitterrificTests: XCTestCase {
     func testMessageID() {
         
         let id = "12345"
-        let action = Applications.Twitterrific.Action.MessageID(id: id)
+        let action = Applications.Twitterrific.Action.messageID(id: id)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["message"])
         XCTAssertEqual(action.paths.app.queryParameters, ["id":id])
@@ -89,7 +89,7 @@ class TwitterrificTests: XCTestCase {
     func testPost() {
         
         let message = "Hi"
-        let action = Applications.Twitterrific.Action.Post(message: message)
+        let action = Applications.Twitterrific.Action.post(message: message)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["post"])
         XCTAssertEqual(action.paths.app.queryParameters, ["message":message])
@@ -99,7 +99,7 @@ class TwitterrificTests: XCTestCase {
     func testUserProfile() {
         
         let screenName = "Iconfactory"
-        let action = Applications.Twitterrific.Action.UserProfile(screenName: screenName)
+        let action = Applications.Twitterrific.Action.userProfile(screenName: screenName)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["profile"])
         XCTAssertEqual(action.paths.app.queryParameters, ["screen_name":screenName])

--- a/Appz/AppzTests/AppsTests/UberTests.swift
+++ b/Appz/AppzTests/AppsTests/UberTests.swift
@@ -22,7 +22,7 @@ class UberTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Uber.Action.Open
+        let action = Applications.Uber.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/UnreadTests.swift
+++ b/Appz/AppzTests/AppsTests/UnreadTests.swift
@@ -22,7 +22,7 @@ class UnreadTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Unread.Action.Open
+        let action = Applications.Unread.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/UstreamTests.swift
+++ b/Appz/AppzTests/AppsTests/UstreamTests.swift
@@ -22,7 +22,7 @@ class UstreamTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Ustream.Action.Open
+        let action = Applications.Ustream.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VIPAccessTests.swift
+++ b/Appz/AppzTests/AppsTests/VIPAccessTests.swift
@@ -22,7 +22,7 @@ class VIPAccessTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.VIPAccess.Action.Open
+        let action = Applications.VIPAccess.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VSCOTests.swift
+++ b/Appz/AppzTests/AppsTests/VSCOTests.swift
@@ -22,7 +22,7 @@ class VSCOTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.VSCO.Action.Open
+        let action = Applications.VSCO.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/ViberTests.swift
+++ b/Appz/AppzTests/AppsTests/ViberTests.swift
@@ -22,7 +22,7 @@ class ViberTests: XCTestCase {
     
     func testCallsTab() {
         
-        let action = Applications.Viber.Action.CallsTab
+        let action = Applications.Viber.Action.callsTab
         
         XCTAssertEqual(action.paths.app.pathComponents, ["calls"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class ViberTests: XCTestCase {
     
     func testChatsTab() {
         
-        let action = Applications.Viber.Action.ChatsTab
+        let action = Applications.Viber.Action.chatsTab
         
         XCTAssertEqual(action.paths.app.pathComponents, ["chats"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VideosTests.swift
+++ b/Appz/AppzTests/AppsTests/VideosTests.swift
@@ -22,7 +22,7 @@ class VideosTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Videos.Action.Open
+        let action = Applications.Videos.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VimeoTests.swift
+++ b/Appz/AppzTests/AppsTests/VimeoTests.swift
@@ -22,7 +22,7 @@ class VimeoTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Vimeo.Action.Open
+        let action = Applications.Vimeo.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VineTests.swift
+++ b/Appz/AppzTests/AppsTests/VineTests.swift
@@ -22,7 +22,7 @@ class VineTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Vine.Action.Open
+        let action = Applications.Vine.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -31,7 +31,7 @@ class VineTests: XCTestCase {
     
     func testTimelinesPopular() {
         
-        let action = Applications.Vine.Action.TimelinesPopular
+        let action = Applications.Vine.Action.timelinesPopular
         
         XCTAssertEqual(action.paths.app.pathComponents, ["timelines", "popular"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VoxTests.swift
+++ b/Appz/AppzTests/AppsTests/VoxTests.swift
@@ -22,7 +22,7 @@ class VoxTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Vox.Action.Open
+        let action = Applications.Vox.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/VoxerTests.swift
+++ b/Appz/AppzTests/AppsTests/VoxerTests.swift
@@ -22,7 +22,7 @@ class VoxerTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Voxer.Action.Open
+        let action = Applications.Voxer.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/WazeTests.swift
+++ b/Appz/AppzTests/AppsTests/WazeTests.swift
@@ -22,7 +22,7 @@ class WazeTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Waze.Action.Open
+        let action = Applications.Waze.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/WeChatTests.swift
+++ b/Appz/AppzTests/AppsTests/WeChatTests.swift
@@ -22,7 +22,7 @@ class WeChatTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.WeChat.Action.Open
+        let action = Applications.WeChat.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/WeiboTests.swift
+++ b/Appz/AppzTests/AppsTests/WeiboTests.swift
@@ -22,7 +22,7 @@ class WeiboTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Weibo.Action.Open
+        let action = Applications.Weibo.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/WhatsAppTests.swift
+++ b/Appz/AppzTests/AppsTests/WhatsAppTests.swift
@@ -22,7 +22,7 @@ class WhatsAppTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.WhatsApp.Action.Open
+        let action = Applications.WhatsApp.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -30,7 +30,7 @@ class WhatsAppTests: XCTestCase {
     }
     
     func testSend(){
-        let action = Applications.WhatsApp.Action.Send(abid: "someId", text: "some Text")
+        let action = Applications.WhatsApp.Action.send(abid: "someId", text: "some Text")
         
         XCTAssertEqual(action.paths.app.pathComponents, ["send"])
         XCTAssertEqual(action.paths.app.queryParameters, ["abid":"someId", "text":"some Text"])

--- a/Appz/AppzTests/AppsTests/WhydTests.swift
+++ b/Appz/AppzTests/AppsTests/WhydTests.swift
@@ -22,7 +22,7 @@ class WhydTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Whyd.Action.Open
+        let action = Applications.Whyd.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/WikipanionTests.swift
+++ b/Appz/AppzTests/AppsTests/WikipanionTests.swift
@@ -22,7 +22,7 @@ class WikipanionTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Wikipanion.Action.Open
+        let action = Applications.Wikipanion.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/WordPressTests.swift
+++ b/Appz/AppzTests/AppsTests/WordPressTests.swift
@@ -22,7 +22,7 @@ class WordPressTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.WordPress.Action.Open
+        let action = Applications.WordPress.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/YahooWeatherTests.swift
+++ b/Appz/AppzTests/AppsTests/YahooWeatherTests.swift
@@ -22,7 +22,7 @@ class YahooWeatherTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.YahooWeather.Action.Open
+        let action = Applications.YahooWeather.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/YammerTests.swift
+++ b/Appz/AppzTests/AppsTests/YammerTests.swift
@@ -22,7 +22,7 @@ class YammerTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Yammer.Action.Open
+        let action = Applications.Yammer.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/YelpTests.swift
+++ b/Appz/AppzTests/AppsTests/YelpTests.swift
@@ -22,7 +22,7 @@ class YelpTests: XCTestCase {
     
     func testOpen() {
         
-        let action = Applications.Yelp.Action.Open
+        let action = Applications.Yelp.Action.open
         
         XCTAssertEqual(action.paths.app.pathComponents, ["app"])
         XCTAssertEqual(action.paths.app.queryParameters, [:])
@@ -32,7 +32,7 @@ class YelpTests: XCTestCase {
     func testSearch() {
         
         let query = "Coffee"
-        let action = Applications.Yelp.Action.Search(query: query)
+        let action = Applications.Yelp.Action.search(query: query)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "search"])
         XCTAssertEqual(action.paths.app.queryParameters, ["terms":query])
@@ -44,7 +44,7 @@ class YelpTests: XCTestCase {
         
         let query = "restaurants"
         let loc = "sf"
-        let action = Applications.Yelp.Action.SearchLocation(query: query, loc: loc)
+        let action = Applications.Yelp.Action.searchLocation(query: query, loc: loc)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "search"])
         XCTAssertEqual(action.paths.app.queryParameters, ["terms":query,
@@ -57,7 +57,7 @@ class YelpTests: XCTestCase {
     func testSearchCategory() {
         
         let cat = "restaurants"
-        let action = Applications.Yelp.Action.SearchCategory(cat: cat)
+        let action = Applications.Yelp.Action.searchCategory(cat: cat)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "search"])
         XCTAssertEqual(action.paths.app.queryParameters, ["category":cat])
@@ -69,7 +69,7 @@ class YelpTests: XCTestCase {
         
         let cat = "restaurants"
         let loc = "Hayes"
-        let action = Applications.Yelp.Action.SearchCatLoc(loc: loc, cat: cat)
+        let action = Applications.Yelp.Action.searchCatLoc(loc: loc, cat: cat)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "search"])
         XCTAssertEqual(action.paths.app.queryParameters, ["category": cat,
@@ -82,7 +82,7 @@ class YelpTests: XCTestCase {
     func testBusiness() {
         
         let id = "the-sentinel-san-francisco"
-        let action = Applications.Yelp.Action.Business(id: id)
+        let action = Applications.Yelp.Action.business(id: id)
         
         XCTAssertEqual(action.paths.app.pathComponents, ["", "biz", id])
         XCTAssertEqual(action.paths.app.queryParameters, [:])

--- a/Appz/AppzTests/AppsTests/YoutubeTests.swift
+++ b/Appz/AppzTests/AppsTests/YoutubeTests.swift
@@ -23,7 +23,7 @@ class YoutubeTests: XCTestCase {
     func testOpen() {
         
         
-        let action = Applications.Youtube.Action.Open()
+        let action = Applications.Youtube.Action.open()
         XCTAssertEqual(action.paths.app.pathComponents, [])
         XCTAssertEqual(action.paths.app.queryParameters,[:])
         
@@ -37,7 +37,7 @@ class YoutubeTests: XCTestCase {
     func testVideo() {
         
         
-        let action = Applications.Youtube.Action.Video(id: "someId")
+        let action = Applications.Youtube.Action.video(id: "someId")
         XCTAssertEqual(action.paths.app.pathComponents, ["watch"])
         XCTAssertEqual(action.paths.app.queryParameters,["v":"someId"])
         

--- a/Appz/AppzTests/EntityTests/ApplicationCallerTests.swift
+++ b/Appz/AppzTests/EntityTests/ApplicationCallerTests.swift
@@ -22,7 +22,7 @@ private struct MalformedApp: ExternalApplication {
 
 class ApplicationCallerTests: XCTestCase {
     
-    private let appCallerMock = ApplicationCallerMock()
+    fileprivate let appCallerMock = ApplicationCallerMock()
     
     
     override func setUp() {
@@ -34,9 +34,9 @@ class ApplicationCallerTests: XCTestCase {
     func testQuery() {
         
         let sampleApp = SampleApp()
-        appCallerMock.open(sampleApp, action: SampleAction())
+        _ = appCallerMock.open(sampleApp, action: SampleAction())
         
-        let expectedURL = NSURL(string: sampleApp.scheme)
+        let expectedURL = URL(string: sampleApp.scheme)
         XCTAssertEqual(appCallerMock.queriedURLs.first, expectedURL)
     }
     
@@ -47,9 +47,9 @@ class ApplicationCallerTests: XCTestCase {
         sampleAction.paths.app = Path()
         
         appCallerMock.canOpenURLs = true
-        appCallerMock.open(sampleApp, action: sampleAction)
+        _ = appCallerMock.open(sampleApp, action: sampleAction)
         
-        let expectedURL = NSURL(string: sampleApp.scheme)
+        let expectedURL = URL(string: sampleApp.scheme)
         XCTAssertEqual(appCallerMock.openedURLs.first, expectedURL)
     }
     
@@ -59,7 +59,7 @@ class ApplicationCallerTests: XCTestCase {
         let sampleAction = SampleAction()
 
         appCallerMock.canOpenURLs = true
-        appCallerMock.open(sampleApp, action: sampleAction)
+        _ = appCallerMock.open(sampleApp, action: sampleAction)
         
         let expectedURL = sampleAction.paths.app.appendToURL(sampleApp.scheme)
         XCTAssertEqual(appCallerMock.openedURLs.first, expectedURL)
@@ -72,7 +72,7 @@ class ApplicationCallerTests: XCTestCase {
         let sampleAction = SampleAction()
         
         appCallerMock.canOpenURLs = true
-        appCallerMock.open(sampleApp, action: sampleAction, promptInstall: true)
+        _ = appCallerMock.open(sampleApp, action: sampleAction, promptInstall: true)
         
         let expectedURL = sampleAction.paths.app.appendToURL(sampleApp.scheme)
         XCTAssertEqual(appCallerMock.openedURLs.first, expectedURL)
@@ -85,11 +85,11 @@ class ApplicationCallerTests: XCTestCase {
         let sampleAction = SampleAction()
         
         let appStore = Applications.AppStore()
-        let appStoreAction = Applications.AppStore.Action.App(id: sampleApp.appStoreId)
+        let appStoreAction = Applications.AppStore.Action.app(id: sampleApp.appStoreId)
         
         appCallerMock.canOpenURLs = false
-        appCallerMock.exceptionURLs = [NSURL(string: appStore.scheme)!]
-        appCallerMock.open(sampleApp, action: sampleAction, promptInstall: true)
+        appCallerMock.exceptionURLs = [URL(string: appStore.scheme)!]
+        _ = appCallerMock.open(sampleApp, action: sampleAction, promptInstall: true)
         
         let expectedURL = appStoreAction.paths.app.appendToURL(appStore.scheme)
         XCTAssertEqual(appCallerMock.openedURLs.first, expectedURL)
@@ -101,7 +101,7 @@ class ApplicationCallerTests: XCTestCase {
         let sampleAction = SampleAction()
         
         appCallerMock.canOpenURLs = false
-        appCallerMock.open(sampleApp, action: sampleAction)
+        _ = appCallerMock.open(sampleApp, action: sampleAction)
         
         let expectedURL = sampleAction.paths.web.appendToURL(sampleApp.fallbackURL)
         XCTAssertEqual(appCallerMock.openedURLs.first, expectedURL)

--- a/Appz/AppzTests/EntityTests/PathTests.swift
+++ b/Appz/AppzTests/EntityTests/PathTests.swift
@@ -19,7 +19,7 @@ class PathTests: XCTestCase {
     
     func testAppendToURL() {
         
-        let expectedURL = NSURL(string: "https://google.com/a/b?1=2&11=22")
+        let expectedURL = URL(string: "https://google.com/a/b?1=2&11=22")
         XCTAssertEqual(path.appendToURL("https://google.com/"), expectedURL)
     }
     
@@ -29,7 +29,7 @@ class PathTests: XCTestCase {
     
     func testAppendToURLWithoutHost() {
         
-        let expectedURL = NSURL(string: "test://a/b?1=2&11=22")
+        let expectedURL = URL(string: "test://a/b?1=2&11=22")
         XCTAssertEqual(path.appendToURL("test:"), expectedURL)
     }
 }

--- a/Appz/AppzTests/Extensions/NSExtensionContextApplicationCallerTests.swift
+++ b/Appz/AppzTests/Extensions/NSExtensionContextApplicationCallerTests.swift
@@ -17,6 +17,6 @@ class NSExtensionContextApplicationCallerTests: XCTestCase {
     }
     
     func testOpenURL() {
-        XCTAssertTrue(NSExtensionContext().openURL(NSURL()))
+        XCTAssertTrue(NSExtensionContext().openURL(URL(string: "https://github.com/SwiftKitz/Appz")!))
     }
 }

--- a/Appz/AppzTests/Mocks/ApplicationCallerMock.swift
+++ b/Appz/AppzTests/Mocks/ApplicationCallerMock.swift
@@ -13,17 +13,17 @@ import Foundation
 class ApplicationCallerMock: ApplicationCaller {
     
     var canOpenURLs = true
-    var exceptionURLs = [NSURL]()
+    var exceptionURLs = [URL]()
     
-    var queriedURLs = [NSURL]()
-    var openedURLs = [NSURL]()
+    var queriedURLs = [URL]()
+    var openedURLs = [URL]()
     
-    func openURL(url: NSURL) -> Bool {
+    func openURL(_ url: URL) -> Bool {
         openedURLs.append(url)
         return true
     }
     
-    func canOpenURL(url: NSURL) -> Bool {
+    func canOpenURL(_ url: URL) -> Bool {
         queriedURLs.append(url)
         return canOpenURLs || exceptionURLs.contains(url)
     }

--- a/Playground/Playground.playground/Contents.swift
+++ b/Playground/Playground.playground/Contents.swift
@@ -9,16 +9,16 @@ import Appz
 //: ## Features
 //: Concise syntax to trigger deeplinking
 
-let app = UIApplication.sharedApplication()
+let app = UIApplication.shared
 app.canOpen(Applications.Instagram())
-app.open(Applications.AppStore(), action: .Account(id: "395107918"))
-app.open(Applications.AppSettings(), action: .Open)
+app.open(Applications.AppStore(), action: .account(id: "395107918"))
+app.open(Applications.AppSettings(), action: .open)
 
 //: Transparent web fallback
 
 // In case the user doesn't have twitter installed, it will fallback to
 // https://twitter.com/statuses/2
-app.open(Applications.Twitter(), action: .Status(id: "2"))
+app.open(Applications.Twitter(), action: .status(id: "2"))
 
 //: Add your own application
 
@@ -41,18 +41,18 @@ extension Applications.MyApp {
     
     enum Action: ExternalApplicationAction {
         
-        case Open
+        case open
         
         // Each action should provide an app path and web path to be
         // added to the associated URL
         var paths: ActionPaths {
             
             switch self {
-            case .Open:
+            case .open:
                 return ActionPaths()
             }
         }
     }
 }
 
-app.open(Applications.MyApp(), action: .Open)
+app.open(Applications.MyApp(), action: .open)

--- a/Playground/Playground.playground/timeline.xctimeline
+++ b/Playground/Playground.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ You can try them in the playground shipped with the framework!
 __Concise syntax to trigger deep linking:__
 
 ```swift
-let app = UIApplication.sharedApplication()
+let app = UIApplication.shared
 app.canOpen(Applications.Instagram())
-app.open(Applications.AppStore(), action: .Account(id: "395107918"))
-app.open(Applications.AppSettings(), action: .Open)
+app.open(Applications.AppStore(), action: .account(id: "395107918"))
+app.open(Applications.AppSettings(), action: .open)
 ```
 
 __Transparent web fallback:__
@@ -55,7 +55,7 @@ __Transparent web fallback:__
 ```swift
 // In case the user doesn't have twitter installed, it will fallback to
 // https://twitter.com/statuses/2
-app.open(Applications.Twitter(), action: .Status(id: "2"))
+app.open(Applications.Twitter(), action: .status(id: "2"))
 ```
 
 __Add your applications:__
@@ -80,21 +80,21 @@ extension Applications.MyApp {
 
     enum Action: ExternalApplicationAction {
 
-        case Open
+        case open
 
         // Each action should provide an app path and web path to be
         // added to the associated URL
         var paths: ActionPaths {
 
             switch self {
-            case .Open:
+            case .open:
                 return ActionPaths()
             }
         }
     }
 }
 
-app.open(Applications.MyApp(), action: .Open)
+app.open(Applications.MyApp(), action: .open)
 ```
 
 __Supported Apps (for now!):__


### PR DESCRIPTION
Salaam,

In ApplicationCallerTests I got 6 warnings of unused result, there are to ways to silent it either by using @discardableResult in function declaration or using _ to explicitly discard the return value. I used _ but if you prefer the other way feel free to tell me to change it.

Also, in NSExtensionContextApplicationCallerTests there was an error it can't accept URL() with empty parameter so I solved it by:
`XCTAssertTrue(NSExtensionContext().openURL(URL(string: "https://github.com/SwiftKitz/Appz")!))`
