### PR TITLE
Added two more apps

### DIFF
--- a/NYTimes.swift
+++ b/NYTimes.swift
@@ -1,0 +1,47 @@
+//
+//  NYTimes.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 9/20/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct NYTimes: ExternalApplication {
+        
+        public typealias ActionType = Applications.NYTimes.Action
+        
+        public let scheme = "nytimes:"
+        public let fallbackURL = "http://www.nytimes.com/services/mobile/index.html"
+        public let appStoreId = "284862083"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.NYTimes {
+    
+    public enum Action {
+        case open
+    }
+}
+
+extension Applications.NYTimes.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/NYTimesTests.swift
+++ b/NYTimesTests.swift
@@ -1,0 +1,31 @@
+//
+//  NYTimesTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 9/20/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class NYTimesTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let NYTimes = Applications.NYTimes()
+        XCTAssertEqual(NYTimes.scheme, "nytimes:")
+        XCTAssertEqual(NYTimes.fallbackURL, "http://www.nytimes.com/services/mobile/index.html")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.NYTimes.Action.open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}

--- a/Skitch.swift
+++ b/Skitch.swift
@@ -1,0 +1,47 @@
+//
+//  Skitch.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 9/20/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Skitch: ExternalApplication {
+        
+        public typealias ActionType = Applications.Skitch.Action
+        
+        public let scheme = "skitch:"
+        public let fallbackURL = "https://evernote.com/skitch/"
+        public let appStoreId = "490505997"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Skitch {
+    
+    public enum Action {
+        case open
+    }
+}
+
+extension Applications.Skitch.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+        
+        switch self {
+        case .open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+        }
+    }
+}

--- a/SkitchTests.swift
+++ b/SkitchTests.swift
@@ -1,0 +1,31 @@
+//
+//  SkitchTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 9/20/16.
+//  Copyright © 2016 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class SkitchTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let skitch = Applications.Skitch()
+        XCTAssertEqual(skitch.scheme, "skitch:")
+        XCTAssertEqual(skitch.fallbackURL, "https://evernote.com/skitch/")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.Skitch.Action.open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+}


### PR DESCRIPTION
Salaam,

I added two more apps so that total number will be 155. I need to edit readme as well but I'm little bit lost because there are two branches. Ok I will do it إن شاء الله when I know how! I'm searching

One small note:
I think we should delete -> Bool from👇🏼

`public func open<E: ExternalApplication>(_ externalApp: E, action: E.ActionType, promptInstall: Bool = false) -> Bool {
`

And we should delete it here as well:

`func openURL(_ url: URL) -> Bool`

Because it's really annoying when developer get this warning and then silent it with let _ 

`Result of call to 'open(_:action:promptInstall:)' is unused`

I got the above warning for each app when I wrote this for example:

`apps.open(Applications.Skitch(), action: .open)`

Do you agree with me?
