### PR TITLE
Added Slack app

### DIFF
--- a/Appz/Appz.xcodeproj/project.pbxproj
+++ b/Appz/Appz.xcodeproj/project.pbxproj
@@ -449,6 +449,11 @@
 		5498D79F1C4A9CD500E88CA9 /* StitcherRadioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5498D79E1C4A9CD500E88CA9 /* StitcherRadioTests.swift */; };
 		5498D7A21C4A9D1D00E88CA9 /* WikipanionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5498D7A11C4A9D1D00E88CA9 /* WikipanionTests.swift */; };
 		5498D7A51C4A9D7900E88CA9 /* YammerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5498D7A41C4A9D7900E88CA9 /* YammerTests.swift */; };
+		54A2803C1E36885D00A0A46C /* Slack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A2803B1E36885D00A0A46C /* Slack.swift */; };
+		54A2803D1E36885D00A0A46C /* Slack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A2803B1E36885D00A0A46C /* Slack.swift */; };
+		54A2803E1E36885D00A0A46C /* Slack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A2803B1E36885D00A0A46C /* Slack.swift */; };
+		54A311841E3507AD0083C6D9 /* SlackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A311801E3507200083C6D9 /* SlackTests.swift */; };
+		54A311851E3507AE0083C6D9 /* SlackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A311801E3507200083C6D9 /* SlackTests.swift */; };
 		54ADFD711C58E7B90064CA1A /* Camera360Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547C832A1C58AC7A00BFD6B6 /* Camera360Tests.swift */; };
 		54ADFD721C58E7BD0064CA1A /* EyeEmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547C832C1C58ACA700BFD6B6 /* EyeEmTests.swift */; };
 		54ADFD731C58E7BF0064CA1A /* PicCollageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547C832E1C58ACD400BFD6B6 /* PicCollageTests.swift */; };
@@ -993,6 +998,8 @@
 		5498D79E1C4A9CD500E88CA9 /* StitcherRadioTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StitcherRadioTests.swift; sourceTree = "<group>"; };
 		5498D7A11C4A9D1D00E88CA9 /* WikipanionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WikipanionTests.swift; sourceTree = "<group>"; };
 		5498D7A41C4A9D7900E88CA9 /* YammerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YammerTests.swift; sourceTree = "<group>"; };
+		54A2803B1E36885D00A0A46C /* Slack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Slack.swift; sourceTree = "<group>"; };
+		54A311801E3507200083C6D9 /* SlackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlackTests.swift; sourceTree = "<group>"; };
 		54C9EB251C3BD9A0005D4DCA /* DailyMotion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DailyMotion.swift; sourceTree = "<group>"; };
 		54C9EB261C3BD9A0005D4DCA /* Trello.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Trello.swift; sourceTree = "<group>"; };
 		54C9EB271C3BD9A0005D4DCA /* Twitterrific.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Twitterrific.swift; sourceTree = "<group>"; };
@@ -1361,6 +1368,7 @@
 				4D37320B1CA438D400352429 /* CirclePayTests.swift */,
 				951714011CA4E0A500C4EBB1 /* FRILTests.swift */,
 				95C2BBA31CA4E32D000F1B35 /* RIDETests.swift */,
+				54A311801E3507200083C6D9 /* SlackTests.swift */,
 			);
 			path = AppsTests;
 			sourceTree = "<group>";
@@ -1595,6 +1603,7 @@
 				82F315A21C38538100CEFE92 /* Youtube.swift */,
 				951713FD1CA4DFA900C4EBB1 /* FRIL.swift */,
 				951714041CA4E21100C4EBB1 /* RIDE.swift */,
+				54A2803B1E36885D00A0A46C /* Slack.swift */,
 			);
 			path = Apps;
 			sourceTree = "<group>";
@@ -1952,6 +1961,7 @@
 				82F315EC1C38538100CEFE92 /* Telegram.swift in Sources */,
 				541C21A01C3D29DB00D89D4A /* MyFitnessPal.swift in Sources */,
 				5415A7A31C58A3AD00598B65 /* AirLaunch.swift in Sources */,
+				54A2803D1E36885D00A0A46C /* Slack.swift in Sources */,
 				541C21901C3D29BF00D89D4A /* Buzzfeed.swift in Sources */,
 				541C219A1C3D29D100D89D4A /* ItunesU.swift in Sources */,
 				5415A7A61C58A3B400598B65 /* Calendars.swift in Sources */,
@@ -2045,6 +2055,7 @@
 				54263BC61C5737830059F828 /* MarktplaatsTests.swift in Sources */,
 				951714031CA4E0A500C4EBB1 /* FRILTests.swift in Sources */,
 				54263BBD1C5737630059F828 /* AllCastTests.swift in Sources */,
+				54A311851E3507AE0083C6D9 /* SlackTests.swift in Sources */,
 				546738961C3996A200AA42F1 /* RemindersAppTests.swift in Sources */,
 				54263BCB1C5737930059F828 /* TangoTests.swift in Sources */,
 				54ADFD741C58E7C20064CA1A /* StravaTests.swift in Sources */,
@@ -2209,6 +2220,7 @@
 				544113F81C3C1F25005A0A65 /* Vine.swift in Sources */,
 				5460FB7D1C497A6F009E35EB /* Currency.swift in Sources */,
 				541C219D1C3D29D500D89D4A /* Marvis.swift in Sources */,
+				54A2803E1E36885D00A0A46C /* Slack.swift in Sources */,
 				546695EC1C41737B000461D2 /* Uber.swift in Sources */,
 				82F315E11C38538100CEFE92 /* Paypal.swift in Sources */,
 				54F649BB1C3EA1CD00619ACF /* Tango.swift in Sources */,
@@ -2453,6 +2465,7 @@
 				54D5D0111C3995EE0039D512 /* ScannerPro.swift in Sources */,
 				5415A7851C58A39900598B65 /* AirLaunch.swift in Sources */,
 				541C21891C3D29BA00D89D4A /* MyFitnessPal.swift in Sources */,
+				54A2803C1E36885D00A0A46C /* Slack.swift in Sources */,
 				541C21811C3D29BA00D89D4A /* Buzzfeed.swift in Sources */,
 				5415A7871C58A39900598B65 /* Calendars.swift in Sources */,
 				541C21861C3D29BA00D89D4A /* ItunesU.swift in Sources */,
@@ -2601,6 +2614,7 @@
 				54F4E11E1C58AB5C008C4794 /* EpsonTests.swift in Sources */,
 				546695EE1C417397000461D2 /* DayCostTests.swift in Sources */,
 				541C21B51C3D2ABA00D89D4A /* SSG2Tests.swift in Sources */,
+				54A311841E3507AD0083C6D9 /* SlackTests.swift in Sources */,
 				54F4E0E91C58A66B008C4794 /* FeedlyTests.swift in Sources */,
 				541C21D91C3D3C0000D89D4A /* BuzzfeedTests.swift in Sources */,
 				546695F11C417407000461D2 /* UberTests.swift in Sources */,

--- a/Appz/Appz/Apps/Slack.swift
+++ b/Appz/Appz/Apps/Slack.swift
@@ -1,0 +1,100 @@
+//
+//  Slack.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/22/17.
+//  Copyright © 2017 kitz. All rights reserved.
+//
+
+public extension Applications {
+    
+    public struct Slack: ExternalApplication {
+        
+        public typealias ActionType = Applications.Slack.Action
+        
+        public let scheme = "slack:"
+        public let fallbackURL = "https://slack.com"
+        public let appStoreId = "803453959"
+        
+        public init() {}
+    }
+}
+
+// MARK: - Actions
+
+public extension Applications.Slack {
+    
+    public enum Action {
+        case open
+        case channel(team: String, id: String)
+        case directMessage(team: String, id: String)
+        case openFile(team: String, fileID: String)
+        case search(team: String, query: String)
+    }
+}
+
+extension Applications.Slack.Action: ExternalApplicationAction {
+    
+    public var paths: ActionPaths {
+    
+        switch self {
+        case .open:
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["app"],
+                    queryParameters: [:]
+                ),
+                web: Path()
+            )
+            
+        case .channel(let team, let id):
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["channel"],
+                    queryParameters: [
+                        "team": team,
+                        "id": id
+                    ]
+                ),
+                web: Path()
+            )
+            
+        case .directMessage(let team, let id):
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["user"],
+                    queryParameters: [
+                        "team": team,
+                        "id": id
+                    ]
+                ),
+                web: Path()
+            )
+            
+        case .openFile(let team, let fileID):
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["file"],
+                    queryParameters: [
+                        "team": team,
+                        "id": fileID
+                    ]
+                ),
+                web: Path()
+            )
+            
+        case .search(let team, let query):
+            return ActionPaths(
+                app: Path(
+                    pathComponents: ["search"],
+                    queryParameters: [
+                        "team": team,
+                        "query": query
+                    ]
+                ),
+                web: Path()
+            )
+        }
+    }
+}
+

--- a/Appz/AppzTests/AppsTests/SlackTests.swift
+++ b/Appz/AppzTests/AppsTests/SlackTests.swift
@@ -1,0 +1,91 @@
+//
+//  SlackTests.swift
+//  Appz
+//
+//  Created by Mariam AlJamea on 1/22/17.
+//  Copyright © 2017 kitz. All rights reserved.
+//
+
+import XCTest
+@testable import Appz
+
+class SlackTests: XCTestCase {
+    
+    let appCaller = ApplicationCallerMock()
+    
+    func testConfiguration() {
+        
+        let slack = Applications.Slack()
+        XCTAssertEqual(slack.scheme, "slack:")
+        XCTAssertEqual(slack.fallbackURL, "https://slack.com")
+    }
+    
+    func testOpen() {
+        
+        let action = Applications.Facebook.Action.open
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["app"])
+        XCTAssertEqual(action.paths.app.queryParameters, [:])
+        XCTAssertEqual(action.paths.web, Path())
+    }
+    
+    func testChannel() {
+        
+        let team = "T0Q22G9C7"
+        let id = "C0REGQG2T"
+        let action = Applications.Slack.Action.channel(team: team, id: id)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["channel"])
+        XCTAssertEqual(action.paths.app.queryParameters, [
+            "team": team,
+            "id": id,
+            ])
+        
+        XCTAssertEqual(action.paths.web.queryParameters, [:])
+    }
+    
+    func testDirectMessage() {
+        
+        let team = "T0Q22G9C7"
+        let id = "USER_ID"
+        let action = Applications.Slack.Action.directMessage(team: team, id: id)
+   
+        XCTAssertEqual(action.paths.app.pathComponents, ["user"])
+        XCTAssertEqual(action.paths.app.queryParameters, [
+            "team": team,
+            "id": id,
+            ])
+        
+        XCTAssertEqual(action.paths.web.queryParameters, [:])
+    }
+    
+    func testOpenFile() {
+        
+        let team = "T0Q22G9C7"
+        let id = "FILE_ID"
+        let action = Applications.Slack.Action.openFile(team: team, fileID: id)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["file"])
+        XCTAssertEqual(action.paths.app.queryParameters, [
+            "team": team,
+            "id": id,
+            ])
+        
+        XCTAssertEqual(action.paths.web.queryParameters, [:])
+    }
+    
+    func testSearch() {
+        
+        let team = "T0Q22G9C7"
+        let query = "rails"
+        let action = Applications.Slack.Action.search(team: team, query: query)
+        
+        XCTAssertEqual(action.paths.app.pathComponents, ["search"])
+        XCTAssertEqual(action.paths.app.queryParameters, [
+            "team": team,
+            "query": query,
+            ])
+        
+        XCTAssertEqual(action.paths.web.queryParameters, [:])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a alt="Carthage Compatible" href="https://github.com/SwiftKitz/Appz#carthage">
     <img alt="Carthage" src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat"/>
   </a>
-  <img alt="Supported Apps" src="https://img.shields.io/badge/Apps-155-9600cd.svg"/>
+  <img alt="Supported Apps" src="https://img.shields.io/badge/Apps-156-9600cd.svg"/>
 </p>
 
 <p align="center">
@@ -210,6 +210,7 @@ App | Actions
 [Simplenote][Simplenote-link] | Open
 [Skitch][Skitch-link] | Open
 [Skype][Skype-link] | Open
+[Slack][Slack-link] | Open, Channel, Direct Message, Open File, Search
 [Snapchat][Snapchat-link] | Open, Add
 [Snapseed][Snapseed-link] | Open
 [Songpop2][Songpop2-link] | Open
@@ -422,6 +423,7 @@ Appz is released under the MIT license. See LICENSE for details.
 [Simplenote-link]: http://simplenote.com
 [Skitch-link]: https://evernote.com/skitch/
 [Skype-link]: http://www.skype.com/
+[Slack-link]: https://api.slack.com/docs/deep-linking#open_slack
 [Snapchat-link]: https://www.snapchat.com
 [Snapseed-link]: https://support.google.com/snapseed/#topic=6155507
 [Songpop2-link]: https://www.songpop2.com


### PR DESCRIPTION
Salaam,

To be honest I just tested open, channel, and search and they worked perfectly. I can't test directMessage and openFile because I'm a new user to slack and I don't have file or DM to test them. When I have I will test them and I will add web: Path() and test it as well.

Here is a useful link that helped me to get team id, channel id .. etc
[https://api.slack.com/methods/auth.test/test](url)

I added slack [doc](https://api.slack.com/docs/deep-linking#open_slack) link in readme table to help other developer, if you want me to change it feel free to tell me.

Thanks.